### PR TITLE
Add sticky position to PDatatable

### DIFF
--- a/src/data-display/tables/data-table/PDataTable.vue
+++ b/src/data-display/tables/data-table/PDataTable.vue
@@ -477,6 +477,8 @@ export default {
         table-layout: fixed;
     }
     th {
+        position: sticky;
+        top: 0;
         z-index: 1;
         vertical-align: bottom;
         line-height: 1.25rem;


### PR DESCRIPTION
### 작업 개요
PDataTable 컴포넌트의 th에 sticky position 추가

### Jira
[[CONSOLE] DataTable 테이블헤더가 고정되어야함](https://pyengine.atlassian.net/browse/CLOUD-3875)

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- .p-data-table .th에 `position: sticky`와 `top: 0` 추가

### 생각해볼 문제
- sticky가 적용되면, copy 아이콘을 눌렀을 때 'copied!' 텍스트가 잘려보이는 경우가 있음(copied! 텍스트가 th를 벗어날 경우)
- 이 문제 때문에 sticky를 없앴던 건데, 없애니까 스크롤 시 th 고정이 안 되어 다시 부활시킴.
- copied 텍스트를 정상적으로 보여줄 방법을 찾아야 함