### PR TITLE
Add using custom style of dropdown in modal

### DIFF
--- a/src/feedbacks/modals/button-modal/PButtonModal.stories.mdx
+++ b/src/feedbacks/modals/button-modal/PButtonModal.stories.mdx
@@ -1,7 +1,9 @@
 import {Meta, Canvas, Story, ArgsTable} from '@storybook/addon-docs/blocks';
 import PButtonModal from "@/feedbacks/modals/button-modal/PButtonModal";
+import PDropdownMenuBtn from "@/inputs/dropdown/dropdown-menu-btn/PDropdownMenuBtn";
+import PSelectDropdown from "@/inputs/dropdown/select-dropdown/PSelectDropdown";
 import { THEME_COLORS, ModalSizeType } from '@/feedbacks/modals/button-modal/type';
-import {computed, reactive, toRefs} from "@vue/composition-api";
+import {computed, reactive, toRefs, onMounted, onUnmounted, ref} from "@vue/composition-api";
 import PButton from "@/inputs/buttons/button/PButton";
 import faker from 'faker';
 
@@ -348,23 +350,111 @@ import faker from 'faker';
 
 export const Template = (args, {argTypes} ) => ({
     props: Object.keys(argTypes),
-    components: { PButtonModal, PButton },
+    components: { PButtonModal, PButton, PDropdownMenuBtn, PSelectDropdown },
     template: `<div>
                 <p-button :styleType="themeColor" @click="launchModal">Launch a modal</p-button>
-                <p-button-modal v-bind="$props"
+                <p-button-modal
                                 :visible.sync="_visible"
-                               @close="closeModal"
+                                :show-popup.sync="isScrolling"
+                                @close="closeModal"
                 >
                     <template #body>
+                        <p-dropdown-menu-btn
+                            :menu="menu"
+                            :use-custom-style="useCustomStyle"
+                            :auto-height="autoHeight"
+                            :show-popup.sync="isScrolling"
+                        >
+                            dropdown menu btn
+                        </p-dropdown-menu-btn>
+                        <p>{{contents}}</p>
+                        <p-select-dropdown
+                            :items="items"
+                            v-model="selectItem"
+                            :use-custom-style="useCustomStyle"
+                            :auto-height="autoHeight"
+                            :show-popup.sync="isScrolling"
+                        >
+                           select dropdown (default)
+                        </p-select-dropdown>
+                        <p>{{contents}}</p>
+                        <p-dropdown-menu-btn
+                            :menu="menu"
+                            :use-custom-style="useCustomStyle"
+                            :auto-height="autoHeight"
+                            :show-popup.sync="isScrolling"
+                        >
+                            dropdown menu btn
+                        </p-dropdown-menu-btn>
                         <p>{{contents}}</p>
                     </template>
                 </p-button-modal>
             </div>`,
     setup(props) {
+        const selectItem = ref('init');
         const state = reactive({
             _visible: props.visible,
             contents: computed(() => faker.lorem.lines(props.contentsHeight)),
-        })
+            menu: [
+                {
+                    type: 'item', label: 'Add', name: 'add', disabled: false,
+                },
+                {
+                    type: 'item', label: 'Hello', name: 'hello', disabled: false,
+                },
+                { type: 'divider' },
+                { type: 'header', label: 'this is header' },
+                {
+                    type: 'item', label: 'Update', name: 'update', disabled: false,
+                },
+                {
+                    type: 'item', label: 'Delete', name: 'delete', disabled: false,
+                },
+                { type: 'divider' },
+                {
+                    type: 'item', label: 'Collect', name: 'collect', disabled: false,
+                },
+                { type: 'divider' },
+                {
+                    type: 'item', label: 'Remove', name: 'remove', disabled: true,
+                },
+            ],
+            autoHeight: true,
+            useCustomStyle: true,
+            isScrolling: false,
+            items: [
+                { type: 'item', label: 'one', name: 'one' },
+                { type: 'item', label: 'two', name: 'two' },
+                { type: 'item', label: 'three', name: 'three' },
+                { type: 'item', label: 'four', name: 'four' },
+                { type: 'item', label: 'five', name: 'five' },
+                { type: 'item', label: 'six', name: 'six' },
+                { type: 'item', label: 'one', name: 'one' },
+                { type: 'item', label: 'two', name: 'two' },
+                { type: 'item', label: 'three', name: 'three' },
+                { type: 'item', label: 'four', name: 'four' },
+                { type: 'item', label: 'five', name: 'five' },
+                { type: 'item', label: 'six', name: 'six' },
+                { type: 'item', label: 'one', name: 'one' },
+                { type: 'item', label: 'two', name: 'two' },
+                { type: 'item', label: 'three', name: 'three' },
+                { type: 'item', label: 'four', name: 'four' },
+                { type: 'item', label: 'five', name: 'five' },
+                { type: 'item', label: 'six', name: 'six' },
+                { type: 'item', label: 'one', name: 'one' },
+                { type: 'item', label: 'two', name: 'two' },
+                { type: 'item', label: 'three', name: 'three' },
+                { type: 'item', label: 'four', name: 'four' },
+                { type: 'item', label: 'five', name: 'five' },
+                { type: 'item', label: 'six', name: 'six' },
+                { type: 'item', label: 'one', name: 'one' },
+                { type: 'item', label: 'two', name: 'two' },
+                { type: 'item', label: 'three', name: 'three' },
+                { type: 'item', label: 'four', name: 'four' },
+                { type: 'item', label: 'five', name: 'five' },
+                { type: 'item', label: 'six', name: 'six' },
+            ]
+        });
         const launchModal = () => {
             state._visible = true;
         };
@@ -372,6 +462,7 @@ export const Template = (args, {argTypes} ) => ({
             state._visible = false;
         };
         return {
+            selectItem,
             ...toRefs(state),
             launchModal,
             closeModal,

--- a/src/feedbacks/modals/button-modal/PButtonModal.vue
+++ b/src/feedbacks/modals/button-modal/PButtonModal.vue
@@ -23,7 +23,9 @@
                                            @click.stop="onCloseClick"
                             />
                         </h3>
-                        <div v-if="bodyVisible" class="modal-body" :class="allBodyClass">
+                        <div v-if="bodyVisible" class="modal-body" :class="allBodyClass"
+                             @scroll="onScroll"
+                        >
                             <slot name="body" />
                         </div>
                         <div v-if="footerVisible" class="modal-footer">
@@ -71,13 +73,19 @@
 <script lang="ts">
 import PButton from '@/inputs/buttons/button/PButton.vue';
 import { sizeMapping } from '@/feedbacks/modals/type';
-import { computed, reactive, toRefs } from '@vue/composition-api';
+import {
+    computed, onMounted, onUnmounted, reactive, toRefs,
+} from '@vue/composition-api';
 import { makeProxy } from '@/util/composition-helpers';
 import { ButtonModalProps } from '@/feedbacks/modals/button-modal/type';
 import '../modal.pcss';
 import PIconButton from '@/inputs/buttons/icon-button/PIconButton.vue';
 import PLottie from '@/foundation/lottie/PLottie.vue';
 
+const documentEventMount = (eventName: string, func: any) => {
+    onMounted(() => document.addEventListener(eventName, func));
+    onUnmounted(() => document.removeEventListener(eventName, func));
+};
 
 export default {
     name: 'PButtonModal',
@@ -144,6 +152,10 @@ export default {
             type: Boolean,
             default: false,
         },
+        showPopup: {
+            type: Boolean,
+            default: false,
+        },
     },
     setup(props: ButtonModalProps, { emit }) {
         const state = reactive({
@@ -186,6 +198,11 @@ export default {
         const onConfirmClick = () => {
             emit('confirm');
         };
+        const onScroll = (event) => {
+            emit('update:showPopup', true);
+        };
+        documentEventMount('scroll', onScroll);
+
         return {
             ...toRefs(state),
             dialogClassObject,
@@ -196,6 +213,7 @@ export default {
             onCloseClick,
             onCancelClick,
             onConfirmClick,
+            onScroll,
         };
     },
 };

--- a/src/feedbacks/modals/button-modal/type.ts
+++ b/src/feedbacks/modals/button-modal/type.ts
@@ -41,4 +41,6 @@ export interface ButtonModalProps {
 
     loading: boolean;
     disabled: boolean;
+
+    showPopup: boolean;
 }

--- a/src/inputs/context-menu/PContextMenu.vue
+++ b/src/inputs/context-menu/PContextMenu.vue
@@ -158,8 +158,8 @@ export default defineComponent({
         onMounted(() => {
             if (!props.autoHeight || !props.useCustomStyle) return;
             const winHeight = window.innerHeight;
-            if (props.position === 'top') state.contextMenuHeight = winHeight - props.offsetTop - props.height - 10;
-            if (props.position === 'bottom') state.contextMenuHeight = props.offsetTop - 10;
+            if (props.position === 'top') state.contextMenuHeight = winHeight - props.offsetTop - props.height - 12;
+            if (props.position === 'bottom') state.contextMenuHeight = props.offsetTop - 12;
         });
 
         let focusedEl: HTMLElement|null = null;

--- a/src/inputs/context-menu/PContextMenu.vue
+++ b/src/inputs/context-menu/PContextMenu.vue
@@ -1,6 +1,7 @@
 <template>
-    <div ref="contextMenu" class="p-context-menu" :class="theme"
-         :style="autoHeightStyle"
+    <div ref="contextMenu" class="p-context-menu"
+         :class="theme"
+         :style="{...autoHeightStyle,...contextMenuStyle}"
          @keyup.esc="onEsc"
     >
         <slot v-if="menu.length === 0" name="no-data" v-bind="{...$props, uuid}">
@@ -76,37 +77,14 @@
 
 <script lang="ts">
 import {
-    computed, ref, onMounted, Ref, watch, defineComponent,
+    computed, ref, onMounted, defineComponent, reactive, toRefs,
 } from '@vue/composition-api';
 
 import PLottie from '@/foundation/lottie/PLottie.vue';
 import PI from '@/foundation/icons/PI.vue';
 
 import { ContextMenuProps, CONTEXT_MENU_THEME } from '@/inputs/context-menu/type';
-import {i18n} from "@/translations";
-
-const setAutoHeight = (props) => {
-    const contextMenu = ref(null) as Ref<HTMLElement|null>;
-    const contextMenuHeight = ref(0);
-    const autoHeightStyle = computed(() => {
-        if (props.autoHeight && contextMenuHeight.value) {
-            return {
-                height: `${contextMenuHeight.value}px`,
-                overflowY: 'auto',
-            };
-        } return null;
-    });
-    onMounted(() => {
-        if (!props.autoHeight) return;
-        const winHeight = window.innerHeight;
-        const rects: any = contextMenu.value?.getBoundingClientRect();
-        if (rects.bottom > winHeight) contextMenuHeight.value = winHeight - rects.top;
-    });
-
-    return {
-        contextMenu, contextMenuHeight, autoHeightStyle,
-    };
-};
+import { i18n } from '@/translations';
 
 export default defineComponent({
     name: 'PContextMenu',
@@ -132,8 +110,58 @@ export default defineComponent({
             type: Boolean,
             default: false,
         },
+        useCustomStyle: {
+            type: Boolean,
+            default: false,
+        },
+        position: {
+            type: String,
+            default: null,
+        },
+        offsetTop: {
+            type: Number,
+            default: null,
+        },
+        width: {
+            type: Number,
+            default: null,
+        },
+        height: {
+            type: Number,
+            default: null,
+        },
     },
     setup(props: ContextMenuProps, { emit }) {
+        const state = reactive({
+            contextMenu: null as HTMLElement|null,
+            contextMenuStyle: computed(() => {
+                if (!state.contextMenu || !props.useCustomStyle) return {};
+                const contextMenuStyle: any = {
+                    position: 'fixed',
+                    minWidth: 'auto',
+                    width: `${props.width}px`,
+                };
+                if (props.position === 'top') contextMenuStyle.top = `calc(${props.offsetTop}px + ${props.height}px)`;
+                if (props.position === 'bottom') contextMenuStyle.bottom = `calc(100vh - ${props.offsetTop}px)`;
+                return contextMenuStyle;
+            }),
+            contextMenuHeight: 0,
+            autoHeightStyle: computed(() => {
+                if (props.autoHeight && state.contextMenuHeight) {
+                    return {
+                        maxHeight: `${state.contextMenuHeight}px`,
+                        overflowY: 'auto',
+                    };
+                } return {};
+            }),
+        });
+        onMounted(() => {
+            if (!props.autoHeight || !props.useCustomStyle) return;
+            const winHeight = window.innerHeight;
+            if (props.position === 'top') state.contextMenuHeight = winHeight - props.offsetTop - props.height - 10;
+            if (props.position === 'bottom') state.contextMenuHeight = props.offsetTop - 10;
+        });
+
         let focusedEl: HTMLElement|null = null;
         const uuid = `${Math.random()}`.slice(2);
         const menuClick = (itemName, index, event) => {
@@ -188,14 +216,13 @@ export default defineComponent({
             blur();
         };
 
-
         return {
+            ...toRefs(state),
             menuClick,
             onDownKey,
             onUpKey,
             focus,
             uuid,
-            ...setAutoHeight(props),
             onEsc,
         };
     },

--- a/src/inputs/context-menu/type.ts
+++ b/src/inputs/context-menu/type.ts
@@ -31,4 +31,9 @@ export interface ContextMenuProps {
     theme: keyof typeof CONTEXT_MENU_THEME;
     loading: boolean;
     autoHeight: boolean;
+    useCustomStyle: boolean;
+    position: string;
+    offsetTop: number;
+    width: number;
+    height: number;
 }

--- a/src/inputs/dropdown/dropdown-btn/PDropdownBtn.vue
+++ b/src/inputs/dropdown/dropdown-btn/PDropdownBtn.vue
@@ -102,7 +102,7 @@ export default defineComponent({
                 const winHeight = window.innerHeight;
                 const rects: any = state.dropdownBtn?.getBoundingClientRect();
                 let position = 'bottom';
-                if (winHeight / 2 > rects.top) position = 'top';
+                if (winHeight * 0.9 > rects.top) position = 'top';
                 emit('update:position', position);
 
                 emit('update:offsetTop', rects.top);

--- a/src/inputs/dropdown/dropdown-btn/PDropdownBtn.vue
+++ b/src/inputs/dropdown/dropdown-btn/PDropdownBtn.vue
@@ -76,7 +76,7 @@ export default defineComponent({
         },
         offsetTop: {
             type: Number,
-            default: 'initial',
+            default: null,
         },
         width: {
             type: Number,
@@ -95,16 +95,16 @@ export default defineComponent({
         const state = reactive({
             mouseover: false,
             dropdownBtn: null as HTMLElement|null,
-            position: 'top',
         });
 
-        const useStyle = () => {
+        const setCustomStyle = () => {
             if (state.dropdownBtn) {
                 const winHeight = window.innerHeight;
                 const rects: any = state.dropdownBtn?.getBoundingClientRect();
-                if (winHeight / 2 > rects.top) state.position = 'top';
-                else state.position = 'bottom';
-                emit('update:position', state.position);
+                let position = 'bottom';
+                if (winHeight / 2 > rects.top) position = 'top';
+                emit('update:position', position);
+
                 emit('update:offsetTop', rects.top);
                 emit('update:width', rects.width);
                 emit('update:height', rects.height);
@@ -114,7 +114,7 @@ export default defineComponent({
         const onClick = () => {
             emit('update:popup', !props.popup);
             emit('update:showPopup', false);
-            if (props.useCustomStyle) useStyle();
+            if (props.useCustomStyle) setCustomStyle();
         };
 
         const onMouseOver = () => {
@@ -130,7 +130,7 @@ export default defineComponent({
             onClick,
             onMouseOver,
             onMouseOut,
-            useStyle,
+            setCustomStyle,
         };
     },
 });

--- a/src/inputs/dropdown/dropdown-btn/PDropdownBtn.vue
+++ b/src/inputs/dropdown/dropdown-btn/PDropdownBtn.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="p-dropdown-btn" :class="{block, 'button-only': buttonOnly}">
+    <div ref="dropdownBtn" class="p-dropdown-btn" :class="{block, 'button-only': buttonOnly}">
         <p-button v-if="!buttonOnly"
                   :disabled="disabled"
                   :tabindex="-1"
@@ -29,7 +29,9 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive, toRefs } from '@vue/composition-api';
+import {
+    defineComponent, reactive, toRefs,
+} from '@vue/composition-api';
 import PButton from '@/inputs/buttons/button/PButton.vue';
 import PIconButton from '@/inputs/buttons/icon-button/PIconButton.vue';
 import { DropdownBtnProps } from '@/inputs/dropdown/dropdown-btn/type';
@@ -68,23 +70,67 @@ export default defineComponent({
                 return Object.keys(ICON_BUTTON_STYLE_TYPE).includes(value as any);
             },
         },
+        useCustomStyle: {
+            type: Boolean,
+            default: false,
+        },
+        offsetTop: {
+            type: Number,
+            default: 'initial',
+        },
+        width: {
+            type: Number,
+            default: null,
+        },
+        height: {
+            type: Number,
+            default: null,
+        },
+        showPopup: {
+            type: Boolean,
+            default: false,
+        },
     },
     setup(props: DropdownBtnProps, { emit }) {
         const state = reactive({
             mouseover: false,
+            dropdownBtn: null as HTMLElement|null,
+            position: 'top',
         });
+
+        const useStyle = () => {
+            if (state.dropdownBtn) {
+                const winHeight = window.innerHeight;
+                const rects: any = state.dropdownBtn?.getBoundingClientRect();
+                if (winHeight / 2 > rects.top) state.position = 'top';
+                else state.position = 'bottom';
+                emit('update:position', state.position);
+                emit('update:offsetTop', rects.top);
+                emit('update:width', rects.width);
+                emit('update:height', rects.height);
+            }
+        };
+
+        const onClick = () => {
+            emit('update:popup', !props.popup);
+            emit('update:showPopup', false);
+            if (props.useCustomStyle) useStyle();
+        };
+
+        const onMouseOver = () => {
+            if (!props.disabled) state.mouseover = true;
+        };
+
+        const onMouseOut = () => {
+            if (!props.disabled) state.mouseover = false;
+        };
+
         return {
             ...toRefs(state),
-            onClick(event): void {
-                emit('click', event);
-                emit('update:popup', !props.popup);
-            },
-            onMouseOver(): void {
-                if (!props.disabled) state.mouseover = true;
-            },
-            onMouseOut(): void {
-                if (!props.disabled) state.mouseover = false;
-            },
+            onClick,
+            onMouseOver,
+            onMouseOut,
+            useStyle,
         };
     },
 });

--- a/src/inputs/dropdown/dropdown-btn/type.ts
+++ b/src/inputs/dropdown/dropdown-btn/type.ts
@@ -10,6 +10,8 @@ export interface DropdownBtnProps {
     buttonIcon?: string;
     buttonStyleType?: keyof BUTTON_STYLE_TYPE;
     useCustomStyle: boolean;
-    position: string;
     width: string;
+    height: string;
+    offsetTop: number;
+    showPopup: boolean;
 }

--- a/src/inputs/dropdown/dropdown-btn/type.ts
+++ b/src/inputs/dropdown/dropdown-btn/type.ts
@@ -9,4 +9,7 @@ export interface DropdownBtnProps {
     buttonOnly: boolean;
     buttonIcon?: string;
     buttonStyleType?: keyof BUTTON_STYLE_TYPE;
+    useCustomStyle: boolean;
+    position: string;
+    width: string;
 }

--- a/src/inputs/dropdown/dropdown-menu-btn/PDropdownMenuBtn.vue
+++ b/src/inputs/dropdown/dropdown-menu-btn/PDropdownMenuBtn.vue
@@ -13,7 +13,7 @@
                         :offset-top.sync="offsetTop"
                         :width.sync="width"
                         :height.sync="height"
-                        :show-popup.sync="proxyshowPopup"
+                        :show-popup.sync="proxyShowPopup"
                         @click="$emit('openMenu')"
         >
             <template v-for="(_, slot) of buttonSlots" v-slot:[slot]="scope">
@@ -124,7 +124,7 @@ export default defineComponent({
                 }
                 return res;
             }, {})),
-            proxyshowPopup: makeProxy('showPopup', props, emit),
+            proxyShowPopup: makeProxy('showPopup', props, emit),
         });
 
         const outsideClick = (): void => {
@@ -140,7 +140,7 @@ export default defineComponent({
 
         watch(() => props.showPopup, (after, before) => {
             if (after) state.popup = false;
-            else state.proxyshowPopup = false;
+            else state.proxyShowPopup = false;
         });
 
         return {

--- a/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
@@ -7,7 +7,7 @@
         :disabled="disabled"
         :loading="loading"
         :use-custom-style="useCustomStyle"
-        :show-popup.sync="_proxyshowPopup"
+        :show-popup.sync="proxyShowPopup"
         @select="changSelectItem"
         @openMenu="$emit('openMenu')"
     >
@@ -79,7 +79,7 @@ export default {
     },
     setup(props: SelectDropdownProps, { emit }) {
         const state = reactive({
-            _proxyshowPopup: makeProxy('showPopup', props, emit),
+            proxyShowPopup: makeProxy('showPopup', props, emit),
         });
         const selectItemLabel = computed(() => {
             if (props.indexMode) {
@@ -103,7 +103,7 @@ export default {
         };
         const invalidClass = computed(() => ({ 'is-invalid-btn': props.invalid }));
         watch(() => props.showPopup, (after, before) => {
-            if (!after) state._proxyshowPopup = false;
+            if (!after) state.proxyShowPopup = false;
         });
         return {
             ...toRefs(state),

--- a/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
@@ -6,6 +6,8 @@
         :auto-height="autoHeight"
         :disabled="disabled"
         :loading="loading"
+        :use-custom-style="useCustomStyle"
+        :show-popup.sync="_proxyshowPopup"
         @select="changSelectItem"
         @openMenu="$emit('openMenu')"
     >
@@ -20,9 +22,12 @@
 
 <script lang="ts">
 import { groupBy } from 'lodash';
-import { computed } from '@vue/composition-api';
+import {
+    computed, toRefs, watch, reactive,
+} from '@vue/composition-api';
 import PDropdownMenuBtn from '@/inputs/dropdown/dropdown-menu-btn/PDropdownMenuBtn.vue';
 import { SelectDropdownProps } from '@/inputs/dropdown/select-dropdown/type';
+import { makeProxy } from '@/util/composition-helpers';
 
 export default {
     name: 'PSelectDropdown',
@@ -63,8 +68,19 @@ export default {
             type: String,
             default: '',
         },
+        useCustomStyle: {
+            type: Boolean,
+            default: false,
+        },
+        showPopup: {
+            type: Boolean,
+            default: false,
+        },
     },
     setup(props: SelectDropdownProps, { emit }) {
+        const state = reactive({
+            _proxyshowPopup: makeProxy('showPopup', props, emit),
+        });
         const selectItemLabel = computed(() => {
             if (props.indexMode) {
                 if (props.items[props.selectItem]) return props.items[props.selectItem].label || props.items[props.selectItem].name || '';
@@ -86,7 +102,11 @@ export default {
             }
         };
         const invalidClass = computed(() => ({ 'is-invalid-btn': props.invalid }));
+        watch(() => props.showPopup, (after, before) => {
+            if (!after) state._proxyshowPopup = false;
+        });
         return {
+            ...toRefs(state),
             selectItemLabel,
             changSelectItem,
             invalidClass,

--- a/src/inputs/dropdown/select-dropdown/type.ts
+++ b/src/inputs/dropdown/select-dropdown/type.ts
@@ -8,6 +8,8 @@ export interface SelectDropdownStateType {
     loading: boolean;
     indexMode: boolean;
     placeholder: string;
+    useCustomStyle: boolean;
+    showPopup: boolean;
 }
 
 export interface SelectDropdownSyncStateType {


### PR DESCRIPTION
### 작업 개요
모달의 DropdownMenuBtn 컴포넌트 개선
### Jira
https://pyengine.atlassian.net/browse/CLOUD-4311

### 작업 분류
- [X] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- 모달의 DropdownMenuBtn 컴포넌트의 메뉴 리스트가 뷰 바깥으로 나가지 않고, 모달 위로 올라오도록 개선

### 생각해볼 문제
- 현재 DropdownMenuBtn이 있는 모달에 스크롤이 되는 경우가 거의 없는데, 모달내 스크롤시 펼쳐져 있던 메뉴리스트가 숨겨지는 코드를 포함시키는게 좋을지 모르겠음.
- 기존 메뉴리스트(PContextMenu)의 autoHeight 스타일 주는것과 이번에 개발된 코드랑 같이 정리할 필요가 있어보임.
