### PR TITLE
feat: add theme to PSelectButtonGroup

### DIFF
--- a/src/inputs/buttons/select-button-group/PSelectButtonGroup.stories.mdx
+++ b/src/inputs/buttons/select-button-group/PSelectButtonGroup.stories.mdx
@@ -66,10 +66,10 @@ import PSelectButtonGroup from '@/inputs/buttons/select-button-group/PSelectButt
                 options: ['one', 'two', 'three', 'four'],
             },
         },
-        buttonType: {
-            name: 'buttonType',
+        theme: {
+            name: 'theme',
             type: {name: 'string'},
-            description: 'Style type of buttons.',
+            description: 'Style theme of buttons.',
             defaultValue: 'default',
             table: {
                 type: {
@@ -96,7 +96,7 @@ export const Template = (args, { argTypes }) => ({
     <p-select-button-group
         :buttons="buttons"
         :selected.sync="selected"
-        :button-type="buttonType"
+        :theme="theme"
         @clickButton="clickButton"
         @click-one="clickOne"
         @click-two="clickTwo"

--- a/src/inputs/buttons/select-button-group/PSelectButtonGroup.stories.mdx
+++ b/src/inputs/buttons/select-button-group/PSelectButtonGroup.stories.mdx
@@ -43,6 +43,9 @@ import PSelectButtonGroup from '@/inputs/buttons/select-button-group/PSelectButt
                     summary: '[]'
                 }
             },
+            control: {
+                type: 'object',
+            },
         },
         selected: {
             name: 'selected',
@@ -62,6 +65,25 @@ import PSelectButtonGroup from '@/inputs/buttons/select-button-group/PSelectButt
                 type: 'select',
                 options: ['one', 'two', 'three', 'four'],
             },
+        },
+        buttonType: {
+            name: 'buttonType',
+            type: {name: 'string'},
+            description: 'Style type of buttons.',
+            defaultValue: 'default',
+            table: {
+                type: {
+                    summary: 'string'
+                },
+                category: 'props',
+                defaultValue: {
+                    summary: 'default'
+                }
+            },
+            control: {
+                type: 'select',
+                options: ['default', 'text'],
+            },
         }
     }}
 />
@@ -74,6 +96,7 @@ export const Template = (args, { argTypes }) => ({
     <p-select-button-group
         :buttons="buttons"
         :selected.sync="selected"
+        :button-type="buttonType"
         @clickButton="clickButton"
         @click-one="clickOne"
         @click-two="clickTwo"

--- a/src/inputs/buttons/select-button-group/PSelectButtonGroup.vue
+++ b/src/inputs/buttons/select-button-group/PSelectButtonGroup.vue
@@ -4,10 +4,10 @@
             <button v-for="(button, idx) in formattedButtons"
                     :key="`${button.name}-${idx}`"
                     class="select-button"
-                    :class="[{ active:selected === button.name }, buttonType]"
+                    :class="[{ active:selected === button.name }, theme]"
                     @click="onClickButton(button.name, idx)"
             >
-                <p-i v-if="selected === button.name && buttonType === 'text'"
+                <p-i v-if="selected === button.name && theme === 'text'"
                      name="ic_check"
                      width="1rem" height="1rem"
                      :color="secondary"
@@ -25,6 +25,7 @@ import {
 
 import PI from '@/foundation/icons/PI.vue';
 import { SelectButtonGroupProps, SelectButtonType } from '@/inputs/buttons/select-button-group/type';
+import { SELECT_BUTTON_GROUP_THEME } from '@/inputs/buttons/select-button-group/config';
 import { secondary } from '@/styles/colors';
 
 export default {
@@ -41,9 +42,12 @@ export default {
             type: String,
             default: '',
         },
-        buttonType: {
+        theme: {
             type: String,
-            default: 'default',
+            default: SELECT_BUTTON_GROUP_THEME.default,
+            validator(theme) {
+                return Object.keys(SELECT_BUTTON_GROUP_THEME).includes(theme);
+            },
         },
     },
     setup(props: SelectButtonGroupProps, context) {

--- a/src/inputs/buttons/select-button-group/PSelectButtonGroup.vue
+++ b/src/inputs/buttons/select-button-group/PSelectButtonGroup.vue
@@ -4,10 +4,15 @@
             <button v-for="(button, idx) in formattedButtons"
                     :key="`${button.name}-${idx}`"
                     class="select-button"
-                    :class="{ active:selected === button.name }"
+                    :class="[{ active:selected === button.name }, buttonType]"
                     @click="onClickButton(button.name, idx)"
             >
-                {{ button.label }}
+                <p-i v-if="selected === button.name && buttonType === 'text'"
+                     name="ic_check"
+                     width="1rem" height="1rem"
+                     :color="secondary"
+                />
+                <span>{{ button.label }}</span>
             </button>
         </div>
     </div>
@@ -18,10 +23,15 @@ import {
     reactive, computed, toRefs,
 } from '@vue/composition-api';
 
+import PI from '@/foundation/icons/PI.vue';
 import { SelectButtonGroupProps, SelectButtonType } from '@/inputs/buttons/select-button-group/type';
+import { secondary } from '@/styles/colors';
 
 export default {
     name: 'PSelectButtonGroup',
+    components: {
+        PI,
+    },
     props: {
         buttons: {
             type: Array,
@@ -30,6 +40,10 @@ export default {
         selected: {
             type: String,
             default: '',
+        },
+        buttonType: {
+            type: String,
+            default: 'default',
         },
     },
     setup(props: SelectButtonGroupProps, context) {
@@ -57,6 +71,7 @@ export default {
         };
         return {
             ...toRefs(state),
+            secondary,
             onClickButton,
         };
     },
@@ -67,6 +82,7 @@ export default {
 .p-select-button-group {
     @apply flex flex-wrap;
     .button-group {
+        display: flex;
         margin-right: -0.5rem;
         margin-bottom: -0.5rem;
     }
@@ -86,6 +102,19 @@ export default {
         }
         &.active {
             @apply border-transparent bg-gray-700 text-white;
+        }
+        &.text {
+            @apply bg-transparent text-gray-500 border-transparent;
+            display: inline-flex;
+            align-items: center;
+            padding-left: 0.5rem;
+            padding-right: 0.5rem;
+            &:hover {
+                @apply bg-transparent;
+            }
+            &.active {
+                @apply text-secondary;
+            }
         }
     }
 }

--- a/src/inputs/buttons/select-button-group/config.ts
+++ b/src/inputs/buttons/select-button-group/config.ts
@@ -1,0 +1,4 @@
+export enum SELECT_BUTTON_GROUP_THEME {
+    default = 'default',
+    text = 'text',
+}

--- a/src/inputs/buttons/select-button-group/type.ts
+++ b/src/inputs/buttons/select-button-group/type.ts
@@ -1,5 +1,7 @@
 import { Button } from '@/inputs/buttons/button/type';
 
+type ButtonType = 'default' | 'text';
+
 export interface SelectButtonType extends Button {
     label: string;
     name: string;
@@ -8,4 +10,5 @@ export interface SelectButtonType extends Button {
 export interface SelectButtonGroupProps {
     buttons: Array<string|SelectButtonType>;
     selected: string | number;
+    buttonType: ButtonType;
 }


### PR DESCRIPTION
### 작업 개요
PSelectButtonGroup에 theme('default' | 'text') 추가
![스크린샷 2021-05-25 오후 1 55 27](https://user-images.githubusercontent.com/18563857/119441300-df8cf880-bd60-11eb-91e2-c552fe6a40c2.png)

### 작업 상세 내용
~~buttonType~~ **theme** props를 추가하여 스타일을 변경할 수 있도록 수정했습니다.