### PR TITLE
feat: add text overflow detection to collapsible panel

### DIFF
--- a/src/data-display/collapsibles/collapsible-list/PCollapsibleList.stories.mdx
+++ b/src/data-display/collapsibles/collapsible-list/PCollapsibleList.stories.mdx
@@ -70,7 +70,7 @@ export const Template = (args, { argTypes }) => ({
     `,
     setup() {
         const state = reactive({
-            items: range(5).map(() => ({ title: faker.lorem.sentence(3), data: faker.lorem.sentence(60) })),
+            items: range(5).map(() => ({ title: faker.lorem.sentence(3), data: faker.lorem.sentence(faker.random.number({min: 30, max: 200})) })),
             unfolded: [0]
         })
         return {
@@ -98,7 +98,7 @@ export const Template = (args, { argTypes }) => ({
     `,
             setup() {
                 const state = reactive({
-                    items: range(5).map(() => ({ title: faker.lorem.sentence(3), data: faker.lorem.sentence(60) })),
+                    items: range(5).map(() => ({ title: faker.lorem.sentence(3), data: faker.lorem.sentence(faker.random.number({min: 30, max: 200})) })),
                     unfolded: [0, 1]
                 })
                 return {
@@ -134,7 +134,7 @@ export const Template = (args, { argTypes }) => ({
     `,
             setup() {
                 const state = reactive({
-                    items: range(3).map(() => ({ title: faker.lorem.sentence(3), data: faker.lorem.sentence(60) }))
+                    items: range(3).map(() => ({ title: faker.lorem.sentence(3), data: faker.lorem.sentence(faker.random.number({min: 30, max: 200})) })),
                 })
                 return {
                     ...toRefs(state)
@@ -156,23 +156,28 @@ export const Template = (args, { argTypes }) => ({
             i18n,
             template: `
     <div class="h-full w-full overflow p-8">
+        <p class="italic mb-4">Line Clamp works only when the toggle position is contents.</p>
         <div class="p-4 mb-4">
-            <p class="text-xl font-bold mb-6">Line Clamp: 5</p>
+            <p class="text-xl font-bold mb-2">Line Clamp: 5</p>
             <p-collapsible-list :items="items" toggle-position="contents" :line-clamp="5" />
         </div>
         <div class="p-4 mb-4">
-            <p class="text-xl font-bold mb-6">Line Clamp: 1 </p>
+            <p class="text-xl font-bold mb-2">Line Clamp: 1 </p>
             <p-collapsible-list :items="items" toggle-position="contents"  :line-clamp="1" />
         </div>
         <div class="p-4 mb-4">
-            <p class="text-xl font-bold mb-6">Line Clamp: 0</p>
+            <p class="text-xl font-bold mb-2">Line Clamp: 0</p>
             <p-collapsible-list :items="items" toggle-position="contents"  :line-clamp="0" />
+        </div>
+        <div class="p-4 mb-4">
+            <p class="text-xl font-bold mb-2">Line Clamp: -1</p>
+            <p-collapsible-list :items="items" toggle-position="contents"  :line-clamp="-1" />
         </div>
     </div>
     `,
             setup() {
                 const state = reactive({
-                    items: range(2).map(() => ({ title: faker.lorem.sentence(3), data: faker.lorem.sentence(30) }))
+                    items: range(3).map(() => ({ title: faker.lorem.sentence(3), data: faker.lorem.sentence(faker.random.number({min: 30, max: 200})) })),
                 })
                 return {
                     ...toRefs(state)
@@ -206,7 +211,7 @@ export const Template = (args, { argTypes }) => ({
     `,
             setup() {
                 const state = reactive({
-                    items: range(4).map(() => ({ title: faker.lorem.sentence(3), data: faker.lorem.sentence(30) }))
+                    items: range(3).map(() => ({ title: faker.lorem.sentence(3), data: faker.lorem.sentence(faker.random.number({min: 30, max: 200})) })),
                 })
                 return {
                     ...toRefs(state)
@@ -262,7 +267,7 @@ export const Template = (args, { argTypes }) => ({
     `,
             setup() {
                 const state = reactive({
-                    items: range(3).map(() => ({ title: faker.lorem.sentence(3), data: faker.lorem.sentence(30) })),
+                    items: range(3).map(() => ({ title: faker.lorem.sentence(3), data: faker.lorem.sentence(faker.random.number({min: 30, max: 200})) })),
                 })
                 return {
                     ...toRefs(state)

--- a/src/data-display/collapsibles/collapsible-list/PCollapsibleList.vue
+++ b/src/data-display/collapsibles/collapsible-list/PCollapsibleList.vue
@@ -14,16 +14,15 @@
                           }"
                     >{{ item.title }}</slot>
                 </span>
-                <p-collapsible-toggle v-if="togglePosition === COLLAPSIBLE_LIST_TOGGLE_POSITION.title || lineClamp === 0"
+                <p-collapsible-toggle v-if="togglePosition === COLLAPSIBLE_LIST_TOGGLE_POSITION.title"
                                       :is-collapsed="!proxyUnfoldedIndices.includes(idx)"
                                       @update:isCollapsed="onUpdateCollapsed(idx, ...arguments)"
                 />
             </p>
-            <div v-if="proxyUnfoldedIndices.includes(idx) ||
-                     (togglePosition === COLLAPSIBLE_LIST_TOGGLE_POSITION.contents && lineClamp > 0)"
-                 class="contents"
-                 :class="{collapsed: !proxyUnfoldedIndices.includes(idx)}"
-                 :style="{'-webkit-line-clamp': lineClamp}"
+            <p-collapsible-panel v-show="togglePosition === COLLAPSIBLE_LIST_TOGGLE_POSITION.contents || proxyUnfoldedIndices.includes(idx)"
+                                 :is-collapsed="!proxyUnfoldedIndices.includes(idx)"
+                                 :line-clamp="togglePosition === COLLAPSIBLE_LIST_TOGGLE_POSITION.contents ? lineClamp : -1"
+                                 @update:isCollapsed="onUpdateCollapsed(idx, ...arguments)"
             >
                 <slot v-bind="{
                     data: item.data,
@@ -34,13 +33,7 @@
                 >
                     {{ item.data }}
                 </slot>
-            </div>
-            <div class="toggle-wrapper">
-                <p-collapsible-toggle v-if="lineClamp > 0 && togglePosition === COLLAPSIBLE_LIST_TOGGLE_POSITION.contents"
-                                      :is-collapsed="!proxyUnfoldedIndices.includes(idx)"
-                                      @update:isCollapsed="onUpdateCollapsed(idx, ...arguments)"
-                />
-            </div>
+            </p-collapsible-panel>
         </div>
     </div>
 </template>
@@ -50,12 +43,14 @@ import {
     ComponentRenderProxy, computed,
     defineComponent, getCurrentInstance, reactive, toRefs, watch,
 } from '@vue/composition-api';
+
+import { makeOptionalProxy } from '@/util/composition-helpers';
 import PCollapsibleToggle from '@/inputs/buttons/collapsible-toggle/PCollapsibleToggle.vue';
 import {
     COLLAPSIBLE_LIST_THEME,
     COLLAPSIBLE_LIST_TOGGLE_POSITION,
 } from '@/data-display/collapsibles/collapsible-list/config';
-import { makeOptionalProxy } from '@/util/composition-helpers';
+import PCollapsiblePanel from '@/data-display/collapsibles/collapsible-panel/PCollapsiblePanel.vue';
 
 interface CollapsibleItem {
     title?: string;
@@ -67,12 +62,12 @@ interface Props {
     unfoldedIndices?: number[];
     lineClamp?: number;
     multiUnfoldable?: boolean;
-    togglePosition?: togglePosition;
+    togglePosition?: COLLAPSIBLE_LIST_TOGGLE_POSITION;
     theme?: COLLAPSIBLE_LIST_THEME;
 }
 export default defineComponent<Props>({
     name: 'PCollapsibleList',
-    components: { PCollapsibleToggle },
+    components: { PCollapsiblePanel, PCollapsibleToggle },
     model: {
         prop: 'unfoldedIndices',
         event: 'update:unfoldedIndices',
@@ -174,25 +169,8 @@ export default defineComponent<Props>({
             line-height: 1.25;
         }
     }
-    .contents {
-        font-size: 0.75rem;
-        line-height: 1.5;
-        word-break: break-word;
-        margin-bottom: 0.5rem;
-        &.collapsed {
-            display: -webkit-box;
-            -webkit-line-clamp: 3;
-            -webkit-box-orient: vertical;
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
-    }
-    .toggle-wrapper {
-        display: flex;
-        justify-content: flex-end;
-        .p-collapsible-toggle {
-            flex-shrink: 0;
-        }
+    .p-collapsible-panel {
+        padding: 0 0 1rem 0;
     }
 
     &.card {

--- a/src/data-display/collapsibles/collapsible-panel/PCollapsiblePanel.stories.mdx
+++ b/src/data-display/collapsibles/collapsible-panel/PCollapsiblePanel.stories.mdx
@@ -64,7 +64,7 @@ export const Template = (args, { argTypes }) => ({
     `,
     setup() {
         const state = reactive({
-            contents: faker.lorem.sentence(40)
+            contents: faker.lorem.sentence(80)
         })
         return {
             ...toRefs(state)
@@ -87,20 +87,27 @@ export const Template = (args, { argTypes }) => ({
             template: `
     <div class="h-full w-full overflow p-8">
         <div class="p-4 mb-8">
-            <p class="text-xl font-bold mb-6">Line Clamp: 5</p>
+            <p class="text-xl font-bold mb-2 border-b">Line Clamp: 5</p>
             <p-collapsible-panel :line-clamp="5">
                 {{contents}}
             </p-collapsible-panel>
         </div>
         <div class="p-4 mb-8">
-            <p class="text-xl font-bold mb-6">Line Clamp: 1 </p>
+            <p class="text-xl font-bold mb-2 border-b">Line Clamp: 1 </p>
             <p-collapsible-panel :line-clamp="1">
                 {{contents}}
             </p-collapsible-panel>
         </div>
         <div class="p-4 mb-8">
-            <p class="text-xl font-bold mb-6">Line Clamp: 0</p>
+            <p class="text-xl font-bold mb-2 border-b">Line Clamp: 0</p>
             <p-collapsible-panel :line-clamp="0">
+                {{contents}}
+            </p-collapsible-panel>
+        </div>
+        <div class="p-4 mb-8">
+            <p class="text-xl font-bold mb-2">Line Clamp: -1</p>
+            <p class="border-b mb-2">If the value is negative, the toggle will be not shown.</p>
+            <p-collapsible-panel :line-clamp="-1">
                 {{contents}}
             </p-collapsible-panel>
         </div>


### PR DESCRIPTION
### 작업 개요
- collapsible panel 에 show/hide 버튼을 text overflow 상태를 감지하여 선택적으로 표시하는 기능 추가
- collapsible panel 에 line clamp negative case 추가
- collapsible list 에서 collapsible panel 을 사용하도록 변경


### 작업 상세 내용
![image](https://user-images.githubusercontent.com/26986739/120969054-a8790700-c7a4-11eb-8aa1-48365c50de7b.png)



