### PR TITLE
feat: add resposive styles, style type, disable copy to definition table

### DIFF
--- a/src/data-display/badges/PBadge.vue
+++ b/src/data-display/badges/PBadge.vue
@@ -73,7 +73,7 @@ export default {
     width: fit-content;
     font-size: 0.75rem;
     line-height: 1;
-    height: 1.25rem;
+    min-height: 1.25rem;
     overflow: hidden;
     letter-spacing: 0.02rem;
     padding: 0 0.5rem;

--- a/src/data-display/dynamic/dynamic-layout/templates/item/index.vue
+++ b/src/data-display/dynamic/dynamic-layout/templates/item/index.vue
@@ -25,7 +25,7 @@ import PPanelTop from '@/data-display/titles/panel-top/PPanelTop.vue';
 import PDefinitionTable from '@/data-display/tables/definition-table/PDefinitionTable.vue';
 import { DefinitionData, DefinitionField } from '@/data-display/tables/definition-table/type';
 import {
-    ItemDynamicLayoutProps, ItemFetchOptions,
+    ItemDynamicLayoutProps,
 } from '@/data-display/dynamic/dynamic-layout/templates/item/type';
 import { DynamicFieldProps } from '@/data-display/dynamic/dynamic-field/type';
 import PDynamicField from '@/data-display/dynamic/dynamic-field/PDynamicField.vue';

--- a/src/data-display/tables/definition-table/PDefinitionTable.stories.mdx
+++ b/src/data-display/tables/definition-table/PDefinitionTable.stories.mdx
@@ -1,94 +1,16 @@
-import { reactive, toRefs } from '@vue/composition-api';
 import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { reactive, toRefs } from '@vue/composition-api';
+
 import PDefinitionTable from '@/data-display/tables/definition-table/PDefinitionTable';
+import { DEFINITION_TABLE_STYLE_TYPE } from '@/data-display/tables/definition-table/config';
+import { getDefinitionTableArgTypes } from '@/data-display/tables/definition-table/story-helper';
 
 <Meta title='Data Display/Tables/Definition Table' parameters={{
     design: {
         type: 'figma',
         url: 'https://www.figma.com/file/wq4wSowBcADBuUrMEZLz6i/SpaceONE-Console-Design?node-id=5373%3A6989',
     }
-}} component={ PDefinitionTable } argTypes={{
-    fields: {
-        name: 'fields',
-        type: { name: 'array' },
-        description: 'Fields of definition table.',
-        defaultValue: [
-            { label: 'Id', name: 'collector_id' },
-            { label: 'Name', name: 'name' },
-            { label: 'Provider', name: 'provider' },
-        ],
-        table: {
-            type: {
-                summary: 'array'
-            },
-            category: 'props',
-            defaultValue: {
-                summary: '[]'
-            }
-        },
-        control: {
-            type: 'object',
-        },
-    },
-    data: {
-        name: 'data',
-        type: { name: 'object' },
-        description: 'Data object of definition table.',
-        defaultValue: {
-            collector_id: 'collector-6746d641c98b',
-            name: 'collector name',
-            provider: 'aws',
-        },
-        table: {
-            type: {
-                summary: 'object',
-            },
-            category: 'props',
-            defaultValue: {
-                summary: 'undefined',
-            },
-        },
-        control: {
-            type: 'object',
-        },
-    },
-    loading: {
-        name: 'loading',
-        type: {name: 'boolean'},
-        description: 'Loading.',
-        defaultValue: false,
-        table: {
-            type: {
-                summary: 'boolean'
-            },
-            category: 'props',
-            defaultValue: {
-                summary: false
-            },
-        },
-        control: {
-            type: 'boolean'
-        }
-    },
-    skeletonRows: {
-        name: 'skeletonRows',
-        type: { name: 'number' },
-        description: 'Rows of skeletons',
-        defaultValue: 5,
-        table: {
-            type: {
-                summary: 'number',
-            },
-            category: 'props',
-            defaultValue: {
-                summary: 5,
-            }
-        },
-        control: {
-            type: 'number'
-        }
-    },
-}}
+}} argTypes={getDefinitionTableArgTypes()}
 />
 
 export const Template = (args, { argTypes }) => ({
@@ -108,7 +30,7 @@ export const Template = (args, { argTypes }) => ({
 });
 
 
-# Definition
+# Definition Table
 
 <br/>
 <br/>
@@ -117,13 +39,66 @@ export const Template = (args, { argTypes }) => ({
 
 ## Basic
 <Canvas>
-    <Story name="basic definition table">
+    <Story name="Basic">
+{{
+    components: { PDefinitionTable },
+    template: `
+<p-definition-table
+    :fields="fields"
+    :data="data"
+/>
+`,
+    setup() {
+        const state = reactive({
+            fields: [
+                { label: 'Id', name: 'collector_id' },
+                { label: 'Name', name: 'name' },
+                { label: 'Provider', name: 'provider' },
+            ],
+            data: {
+                collector_id: 'collector-6746d641c98b',
+                name: 'collector name',
+                provider: 'aws',
+            }
+        });
+        return {
+            ...toRefs(state),
+        }
+    }
+}}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
+
+## No Data
+<Canvas>
+    <Story name="No Data">
+        {{
+            components: { PDefinitionTable },
+            template: `
+<p-definition-table />
+`,
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
+## Loading
+
+<Canvas>
+    <Story name="Loading">
         {{
             components: { PDefinitionTable },
             template: `
 <p-definition-table
     :fields="fields"
     :data="data"
+    loading
 />
 `,
             setup() {
@@ -147,56 +122,228 @@ export const Template = (args, { argTypes }) => ({
     </Story>
 </Canvas>
 
+<br/>
+<br/>
 
-## No Data
+## Slots
+
+| Slot name | Description |
+| ---- | ----------- |
+| data | Slot for all definition field value. It has the highest priority among field value slots. |
+| data-{field index} | Slot for definition field value that matched for the field index. It has the second highest priority among field value slots. |
+| data-{field.name} | Slot for definition field value. Use it only when all field names are distinct. Otherwise, it can cause unexpected error. It's useful when field names are duplicated. * Don't use 'data-{field.name}' slot together. It can cause multiple definition field. It has the lowest priority among field value slots. |
+| key | Slot for replacing field key text. |
+| loading | Slot for replacing loader. |
+| no-data | Slot for no data case. |
+
+<br/>
+<br/>
+
+### SlotScope(Props)
+
+<br/>
+
+> Except for `no-data` and `loading` slots, all slots provide slot props below:
+
+| Type | Description |
+| ---- | ----------- |
+| name | The name of the item. |
+| label | The label of the item. |
+| data | The data of the item. |
+| value | The actual data. it's usually the same with 'data'. it's different only when 'formatter(data)' is different value with 'data'. |
+| copy | The function that invoked when copy button is clicked. |
+| hoverCopy | Indication of copy button is hovered. |
+| items | All field and data items ordered by `fields` props. |
+| index | Current item's index. |
+
+<br/>
+<br/>
+
 <Canvas>
-    <Story name="no data definition table">
+    <Story name="Slots">
+{{
+    components: { PDefinitionTable },
+    template: `
+<div>
+    <p class="mb-4 text-lg font-bold">Slot: data</p>
+    <p-definition-table
+        :fields="fields"
+        :data="data"
+    >
+        <template #data="{value}">
+            <span class="text-secondary-dark">{{value}}</span>
+        </template>
+    </p-definition-table>
+    <p class="mb-4 text-lg font-bold">Slot: data-{field.name}</p>
+    <p-definition-table
+        :fields="fields"
+        :data="data"
+    >
+        <template #data-name="{value}">
+            <span class="text-secondary-dark">{{value}}</span>
+        </template>
+    </p-definition-table>
+    <p class="mb-4 text-lg font-bold">Slot: data-{field index}</p>
+    <p-definition-table
+        :fields="fields"
+        :data="data"
+    >
+        <template #data-name="{index, value}">
+            <span class="text-secondary-dark">{{index}}. {{value}}</span>
+        </template>
+    </p-definition-table>
+    <p class="my-4 text-lg font-bold">Slot: key</p>
+    <p-definition-table
+        :fields="fields"
+        :data="data"
+    >
+        <template #key="{label}">
+            <span class="text-secondary-dark">{{label}}</span>
+        </template>
+    </p-definition-table>
+    <p class="my-4 text-lg font-bold">Slot: loading</p>
+    <p-definition-table
+        :fields="fields"
+        :data="data"
+        loading
+    >
+        <template #loading>
+            <span class="text-secondary-dark">Loading...</span>
+        </template>
+    </p-definition-table>
+    <p class="my-4 text-lg font-bold">Slot: no-data</p>
+    <p-definition-table
+        :fields="fields"
+        :data="{}"
+    >
+        <template #no-data>
+            <span class="text-secondary-dark">No Data</span>
+        </template>
+    </p-definition-table>
+</div>
+<!--<div>-->
+`,
+    setup() {
+        const state = reactive({
+            fields: [
+                { label: 'Id', name: 'collector_id' },
+                { label: 'Name', name: 'name' },
+                { label: 'Provider', name: 'provider' },
+            ],
+            data: {
+                collector_id: 'collector-6746d641c98b',
+                name: 'collector name',
+                provider: 'aws',
+            }
+        });
+        return {
+            ...toRefs(state),
+        }
+    }
+}}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
+
+## Disable Copy
+
+<Canvas>
+    <Story name="Disable Copy">
         {{
             components: { PDefinitionTable },
             template: `
-<p-definition-table />
+<p-definition-table
+    :fields="fields"
+    :data="data"
+    disable-copy
+/>
 `,
+            setup() {
+                const state = reactive({
+                    fields: [
+                        { label: 'Id', name: 'collector_id' },
+                        { label: 'Name', name: 'name' },
+                        { label: 'Provider', name: 'provider' },
+                    ],
+                    data: {
+                        collector_id: 'collector-6746d641c98b',
+                        name: 'collector name',
+                        provider: 'aws',
+                    }
+                });
+                return {
+                    ...toRefs(state),
+                }
+            }
         }}
     </Story>
 </Canvas>
 
+<br/>
+<br/>
+
+
+## Style Types
+
+<Canvas>
+    <Story name="Style Types">
+        {{
+            components: { PDefinitionTable },
+            template: `
+<div>
+    <p class="mb-4 text-lg font-bold">Style Type: {{DEFINITION_TABLE_STYLE_TYPE.primary}}</p>
+    <p-definition-table
+        :fields="fields"
+        :data="data"
+        :style-type="DEFINITION_TABLE_STYLE_TYPE.primary"
+    />
+    <p class="mb-4 text-lg font-bold">Style Type: {{DEFINITION_TABLE_STYLE_TYPE.white}}</p>
+    <p-definition-table
+        :fields="fields"
+        :data="data"
+        :style-type="DEFINITION_TABLE_STYLE_TYPE.white"
+    />
+</div>
+`,
+            setup() {
+                const state = reactive({
+                    fields: [
+                        { label: 'Id', name: 'collector_id' },
+                        { label: 'Name', name: 'name' },
+                        { label: 'Provider', name: 'provider' },
+                    ],
+                    data: {
+                        collector_id: 'collector-6746d641c98b',
+                        name: 'collector name',
+                        provider: 'aws',
+                    }
+                });
+                return {
+                    ...toRefs(state),
+                    DEFINITION_TABLE_STYLE_TYPE
+                }
+            }
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
+
 ## Playground
 <Canvas>
-    <Story name="playground" >
+    <Story name="Playground" >
         {Template.bind({})}
     </Story>
 </Canvas>
 
-<ArgsTable story="playground" />
+<ArgsTable story="Playground" />
 
 <br/>
 
-## Description
 
-<br/>
 
-### Slots
-| Slot name | Description |
-| ---- | ----------- |
-| data-{field index} | Slot for definition field. |
-| data-{field.name} | Slot for definition field. Use it only when all field names are distinct. Otherwise, it can cause unexpected error. It's useful when field names are duplicated. * Don't use 'data-{field.name}' slot together. It can cause multiple definition field. |
-| no-data | Slot for no data case. |
-| copy | Slot for all copy button. It replaces all copy button. |
-| copy-{field index} | Slot for field's copy button. |
-| copy-{field.name} | Slot for field's copy button. Use it only when all field names are distinct. Otherwise, it can cause unexpected error. |
-
-<br/>
-
-### SlotScope(Props)
-* Except for 'no-data' slot, all slots provide slot props.
-
-| Type | Description |
-| ---- | ----------- |
-| all Props | name, label, data, disableCopy, formatter |
-| field | 'td' element that wrapping definition text. |
-| displayData | actual data. it's usually the same with 'data'. it's different only when 'formatter(data)' is different value with 'data'. |
-| showCopy | boolean value that indicates whether show copy or not. it's related the value of 'displayData', 'disableCopy', and field element's innerText. |
-| copy | function that invoked when copy button is clicked. |
-| isMouseOver | boolean value that indicates whether copy button is mouse over or out. |
-| onMouseOver | function that invoked when copy button is mouse over. |
-| onMouseOut | function that invoked when copy button is mouse out. |

--- a/src/data-display/tables/definition-table/PDefinitionTable.stories.mdx
+++ b/src/data-display/tables/definition-table/PDefinitionTable.stories.mdx
@@ -2,6 +2,7 @@ import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs/blocks';
 import { reactive, toRefs } from '@vue/composition-api';
 
 import PDefinitionTable from '@/data-display/tables/definition-table/PDefinitionTable';
+import PButton from '@/inputs/buttons/button/PButton';
 import { DEFINITION_TABLE_STYLE_TYPE } from '@/data-display/tables/definition-table/config';
 import { getDefinitionTableArgTypes } from '@/data-display/tables/definition-table/story-helper';
 
@@ -133,6 +134,7 @@ export const Template = (args, { argTypes }) => ({
 | data-{field index} | Slot for definition field value that matched for the field index. It has the second highest priority among field value slots. |
 | data-{field.name} | Slot for definition field value. Use it only when all field names are distinct. Otherwise, it can cause unexpected error. It's useful when field names are duplicated. * Don't use 'data-{field.name}' slot together. It can cause multiple definition field. It has the lowest priority among field value slots. |
 | key | Slot for replacing field key text. |
+| extra | Slot for right space of field value. |
 | loading | Slot for replacing loader. |
 | no-data | Slot for no data case. |
 
@@ -162,7 +164,7 @@ export const Template = (args, { argTypes }) => ({
 <Canvas>
     <Story name="Slots">
 {{
-    components: { PDefinitionTable },
+    components: { PDefinitionTable, PButton },
     template: `
 <div>
     <p class="mb-4 text-lg font-bold">Slot: data</p>
@@ -199,6 +201,15 @@ export const Template = (args, { argTypes }) => ({
     >
         <template #key="{label}">
             <span class="text-secondary-dark">{{label}}</span>
+        </template>
+    </p-definition-table>
+    <p class="my-4 text-lg font-bold">Slot: extra</p>
+    <p-definition-table
+        :fields="fields"
+        :data="data"
+    >
+        <template #extra="{label}">
+            <div class="text-peacock mr-4 w-full text-right"><p-button style-type="secondary" size="sm">Edit</p-button></div>
         </template>
     </p-definition-table>
     <p class="my-4 text-lg font-bold">Slot: loading</p>

--- a/src/data-display/tables/definition-table/PDefinitionTable.vue
+++ b/src/data-display/tables/definition-table/PDefinitionTable.vue
@@ -33,6 +33,9 @@
                     <template v-if="$scopedSlots.key" #key="scope">
                         <slot name="key" v-bind="{...scope, index: idx, items}" />
                     </template>
+                    <template #extra="scope">
+                        <slot name="extra" v-bind="scope" />
+                    </template>
                 </p-definition>
             </tbody>
         </table>

--- a/src/data-display/tables/definition-table/PDefinitionTable.vue
+++ b/src/data-display/tables/definition-table/PDefinitionTable.vue
@@ -36,7 +36,7 @@
 import { every, range, get } from 'lodash';
 
 import {
-    computed, reactive, toRefs, watch,
+    computed, defineComponent, reactive, toRefs, watch,
 } from '@vue/composition-api';
 
 import {
@@ -52,7 +52,7 @@ const makeDefItems = (fields: DefinitionField[], data?: DefinitionData): Definit
     data: get(data, item.name, ''),
 }));
 
-export default {
+export default defineComponent<DefinitionTableProps>({
     name: 'PDefinitionTable',
     components: {
         PLottie, PEmpty, PDefinition,
@@ -95,7 +95,7 @@ export default {
             },
         };
     },
-};
+});
 </script>
 
 <style lang="postcss">

--- a/src/data-display/tables/definition-table/config.ts
+++ b/src/data-display/tables/definition-table/config.ts
@@ -1,0 +1,7 @@
+export
+const DEFINITION_TABLE_STYLE_TYPE = Object.freeze({
+    primary: 'primary',
+    white: 'white',
+} as const);
+
+export type DEFINITION_TABLE_STYLE_TYPE = typeof DEFINITION_TABLE_STYLE_TYPE[keyof typeof DEFINITION_TABLE_STYLE_TYPE];

--- a/src/data-display/tables/definition-table/definition/PDefinition.stories.mdx
+++ b/src/data-display/tables/definition-table/definition/PDefinition.stories.mdx
@@ -1,106 +1,19 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs/blocks';
 import {
     toRefs, reactive,
 } from '@vue/composition-api';
-import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs/blocks';
-import PDefinition from '@/data-display/tables/definition-table/definition/PDefinition.vue';
+import faker from 'faker'
 
-<Meta title='Data Display/Tables/Definition Table/Definition Item' parameters={{
+import PButton from '@/inputs/buttons/button/PButton';
+import PDefinition from '@/data-display/tables/definition-table/definition/PDefinition.vue';
+import { getDefinitionArgTypes } from '@/data-display/tables/definition-table/definition/story-helper';
+
+<Meta title='Data Display/Tables/Definition Table/Definition' parameters={{
     design: {
         type: 'figma',
         url: 'https://www.figma.com/file/wq4wSowBcADBuUrMEZLz6i/SpaceONE-Console-Design?node-id=5373%3A6989',
     }
-}} component={ PDefinition } argTypes={{
-    name: {
-        name: 'name',
-        type: {name: 'string'},
-        description: 'Name of key.',
-        defaultValue: 'name',
-        table: {
-            type: {
-                summary: 'string'
-            },
-            category: 'props',
-            defaultValue: {
-                summary: '""'
-            }
-        },
-        control: {
-            type: 'text'
-        },
-    },
-    label: {
-        name: 'label',
-        type: {name: 'string'},
-        description: 'Label of key.',
-        defaultValue: 'label',
-        table: {
-            type: {
-                summary: 'string'
-            },
-            category: 'props',
-            defaultValue: {
-                summary: '""'
-            }
-        },
-        control: {
-            type: 'text'
-        },
-    },
-    data: {
-        name: 'data',
-        type: {name: 'string'},
-        description: 'Data of value.',
-        defaultValue: 'data',
-        table: {
-            type: {
-                summary: 'string, object, array, boolean, number'
-            },
-            category: 'props',
-            defaultValue: {
-                summary: '""'
-            }
-        },
-        control: {
-            type: 'text'
-        },
-    },
-    disableCopy: {
-        name: 'disableCopy',
-        type: {name: 'boolean'},
-        description: 'Disable copy button when true',
-        defaultValue: false,
-        table: {
-            type: {
-                summary: 'boolean'
-            },
-            category: 'props',
-            defaultValue: {
-                summary: false,
-            }
-        },
-        control: {
-            type: 'boolean',
-        }
-    },
-    formatter: {
-        name: 'formatter',
-        type: {name: 'function'},
-        description: `formatter that format the data.`,
-        defaultValue: undefined,
-        table: {
-            type: {
-                summary: 'function'
-            },
-            category: 'props',
-            defaultValue: {
-                summary: `undefined`
-            },
-        },
-        control: {
-            type: 'object',
-        }
-    }
-}}
+}} argTypes={getDefinitionArgTypes()}
 />
 
 
@@ -114,8 +27,9 @@ export const Template = (args, { argTypes }) => ({
     :data="data"
     :disable-copy="disableCopy"
     :formatter="formatter"
-/>`,
-    setup() {
+>
+</p-definition>`,
+    setup(props) {
         return {
         }
     }
@@ -130,8 +44,9 @@ export const Template = (args, { argTypes }) => ({
 
 
 ## Basic
+
 <Canvas>
-    <Story name="basic definition">
+    <Story name="Basic">
         {{
             components:{ PDefinition },
             template: `
@@ -178,9 +93,33 @@ export const Template = (args, { argTypes }) => ({
     </Story>
 </Canvas>
 
-## Formatter
+## Disable Copy
+
 <Canvas>
-    <Story name="formatted definition">
+    <Story name="Disable Copy">
+{{
+    components:{ PDefinition },
+    template: `
+        <p-definition
+            :label="label"
+            :data="data"
+            disable-copy
+        />
+`,
+    setup() {
+        return {
+            label: faker.lorem.sentence(5),
+            data: faker.lorem.sentence(20)
+        }
+    }
+}}
+    </Story>
+</Canvas>
+
+## With Formatter
+
+<Canvas>
+    <Story name="With Formatter">
         {{
             components:{ PDefinition },
             template: `
@@ -215,37 +154,78 @@ export const Template = (args, { argTypes }) => ({
     </Story>
 </Canvas>
 
-## Playground
-<Canvas>
-    <Story name="playground" >
-        {Template.bind({})}
-    </Story>
-</Canvas>
-
-<ArgsTable story="playground" />
-
+<br/>
 <br/>
 
-## Description
-
-<br/>
-
-### Slots
+## Slots
 | Slot name | Description |
 | ---- | ----------- |
-| default | Slot for replacing definition text. |
-| copy | Slot for replacing copy button. |
+| default | Slot for replacing definition(value) text. |
+| key | Slot for replacing key text. |
+| extra | Slot for right space of value. |
 
 <br/>
 
 ### SlotScope(Props)
 | Type | Description |
 | ---- | ----------- |
-| all Props | name, label, data, disableCopy, formatter |
-| field | 'td' element that wrapping definition text. |
-| displayData | actual data. it's usually the same with 'data'. it's different only when 'formatter(data)' is different value with 'data'. |
-| showCopy | boolean value that indicates whether show copy or not. it's related the value of 'displayData', 'disableCopy', and field element's innerText. |
+| name | name props. |
+| label | label props. |
+| data | data props. |
+| value | actual data. it's usually the same with 'data'. it's different only when 'formatter(data)' is different value with 'data'. |
 | copy | function that invoked when copy button is clicked. |
-| isMouseOver | boolean value that indicates whether copy button is mouse over or out. |
-| onMouseOver | function that invoked when copy button is mouse over. |
-| onMouseOut | function that invoked when copy button is mouse out. |
+| hoverCopy | Indication of copy button is hovered. |
+
+<br/>
+
+
+<Canvas>
+    <Story name="Slots">
+{{
+    components:{ PDefinition, PButton },
+    template: `
+<table>
+    <tbody>
+        <p-definition
+            name="Key Slot"
+            data="Slot: key"
+        >
+            <template #key="{value}">
+                <span class="text-peacock">{{value}}</span>
+            </template>
+        </p-definition>
+        <p-definition
+            name="Default Slot"
+            data="Slot: default"
+        >
+            <template #default="{value, hoverCopy}">
+                <span :class="hoverCopy ? 'text-secondary' : 'text-peacock'">{{value}}</span>
+            </template>
+        </p-definition>
+        <p-definition
+            name="Extra Slot"
+            data="Slot: extra"
+        >
+            <template #extra>
+                <div class="text-peacock ml-4 w-full"><p-button style-type="secondary" size="sm">Edit</p-button></div>
+            </template>
+        </p-definition>
+    </tbody>
+</table>
+<!--<div>-->
+`,
+}}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
+## Playground
+<Canvas>
+    <Story name="Playground" >
+        {Template.bind({})}
+    </Story>
+</Canvas>
+
+<ArgsTable story="Playground" />

--- a/src/data-display/tables/definition-table/definition/PDefinition.vue
+++ b/src/data-display/tables/definition-table/definition/PDefinition.vue
@@ -115,5 +115,14 @@ export default defineComponent<DefinitionProps>({
         line-height: 1.45;
         cursor: unset;
     }
+
+    @screen mobile {
+        flex-wrap: no-wrap;
+        flex-direction: column;
+        .key, .value-wrapper {
+            width: 100%;
+            max-width: 100%;
+        }
+    }
 }
 </style>

--- a/src/data-display/tables/definition-table/definition/PDefinition.vue
+++ b/src/data-display/tables/definition-table/definition/PDefinition.vue
@@ -1,19 +1,24 @@
 <template>
     <tr class="p-definition">
         <td class="key">
-            {{ label || name }}
-        </td>
-        <td ref="field" class="value" :class="{hover: isMouseOver}">
-            <slot name="default" v-bind="{...$props, ...$data}">
-                {{ displayData }}
+            <slot name="key" v-bind="{name, label, data, value: displayData, hoverCopy: isMouseOver, copy}">
+                {{ label || name }}
             </slot>
-            <slot name="copy" v-bind="{...$props, ...$data}">
+        </td>
+        <td class="value-wrapper">
+            <span ref="field" class="value" :class="{hover: isMouseOver}">
+                <slot name="default" v-bind="{name, label, data, value: displayData, hoverCopy: isMouseOver, copy}">
+                    {{ displayData }}
+                </slot>
                 <p-copy-button v-if="showCopy"
-                               class="ml-2" width="0.8rem" height="0.8rem"
+                               width="0.8rem" height="0.8rem"
                                @copy="copy"
                                @mouseover="onMouseOver()" @mouseout="onMouseOut()"
                 />
-            </slot>
+            </span>
+            <span class="extra">
+                <slot name="extra" v-bind="{name, label, data, value: displayData, hoverCopy: isMouseOver, copy}" />
+            </span>
         </td>
     </tr>
 </template>
@@ -26,6 +31,8 @@ import { copyAnyData, copyTextToClipboard, isNotEmpty } from '@/util/helpers';
 import PCopyButton from '@/inputs/buttons/copy-button/PCopyButton.vue';
 import { mouseOverState } from '@/hooks/mouse-over-state';
 import { DefinitionProps } from '@/data-display/tables/definition-table/definition/type';
+
+const searchElemInnerText = (elem: HTMLElement): string => elem.innerText;
 
 export default defineComponent<DefinitionProps>({
     name: 'PDefinition',
@@ -53,7 +60,6 @@ export default defineComponent<DefinitionProps>({
         },
     },
     setup(props: DefinitionProps, { emit, slots }) {
-        const searchElemInnerText = (elem: HTMLElement): string => elem.innerText;
         const state = reactive({
             field: null as HTMLFormElement|null,
             displayData: computed(() => (props.formatter ? props.formatter(props.data, props) : props.data)),
@@ -87,15 +93,24 @@ export default defineComponent<DefinitionProps>({
         @apply font-bold;
         width: 18rem;
     }
-    .value {
+    .value-wrapper {
         @apply inline-flex items-center flex-grow cursor-text;
         flex-wrap: wrap;
         max-width: calc(100% - 18rem);
-        &.hover {
-            @apply text-blue-500;
+        .value {
+            &.hover {
+                @apply text-blue-500;
+            }
+        }
+        .p-copy-button {
+            @apply ml-2 flex-shrink-0;
+        }
+        .extra {
+            flex-grow: 1;
+            flex-shrink: 0;
         }
     }
-    .key, .value {
+    .key, .value-wrapper {
         @apply py-2 px-4 text-sm;
         line-height: 1.45;
         cursor: unset;

--- a/src/data-display/tables/definition-table/definition/PDefinition.vue
+++ b/src/data-display/tables/definition-table/definition/PDefinition.vue
@@ -20,14 +20,14 @@
 
 <script lang="ts">
 import {
-    computed, reactive, toRefs,
+    computed, defineComponent, reactive, toRefs,
 } from '@vue/composition-api';
-import { DefinitionProps } from '@/data-display/tables/definition-table/definition/type';
 import { copyAnyData, copyTextToClipboard, isNotEmpty } from '@/util/helpers';
 import PCopyButton from '@/inputs/buttons/copy-button/PCopyButton.vue';
 import { mouseOverState } from '@/hooks/mouse-over-state';
+import { DefinitionProps } from '@/data-display/tables/definition-table/definition/type';
 
-export default {
+export default defineComponent<DefinitionProps>({
     name: 'PDefinition',
     components: { PCopyButton },
     props: {
@@ -77,7 +77,7 @@ export default {
             copy,
         };
     },
-};
+});
 </script>
 
 <style lang="postcss">

--- a/src/data-display/tables/definition-table/definition/story-helper.ts
+++ b/src/data-display/tables/definition-table/definition/story-helper.ts
@@ -1,0 +1,134 @@
+import { ArgTypes } from '@storybook/addons';
+
+export const getDefinitionArgTypes = (): ArgTypes => ({
+    name: {
+        name: 'name',
+        type: { name: 'string' },
+        description: 'Name of key.',
+        defaultValue: 'name',
+        table: {
+            type: {
+                summary: 'string',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: '""',
+            },
+        },
+        control: {
+            type: 'text',
+        },
+    },
+    label: {
+        name: 'label',
+        type: { name: 'string' },
+        description: 'Label of key.',
+        defaultValue: 'label',
+        table: {
+            type: {
+                summary: 'string',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: '""',
+            },
+        },
+        control: {
+            type: 'text',
+        },
+    },
+    data: {
+        name: 'data',
+        type: { name: 'any' },
+        description: 'Data for value.',
+        defaultValue: 'data',
+        table: {
+            type: {
+                summary: 'any',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: '""',
+            },
+        },
+        control: {
+            type: 'text',
+        },
+    },
+    disableCopy: {
+        name: 'disableCopy',
+        type: { name: 'boolean' },
+        description: 'Whether to disable copy button or not.',
+        defaultValue: false,
+        table: {
+            type: {
+                summary: 'boolean',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: false,
+            },
+        },
+        control: {
+            type: 'boolean',
+        },
+    },
+    formatter: {
+        name: 'formatter',
+        type: { name: 'function' },
+        description: 'A function that receives `data` props and all props as arguments, and returns display data for value.',
+        defaultValue: undefined,
+        table: {
+            type: {
+                summary: 'function',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: 'undefined',
+            },
+        },
+    },
+    /* slots */
+    defaultSlot: {
+        name: 'default',
+        description: 'Slot for value.',
+        defaultValue: null,
+        table: {
+            type: {
+                summary: null,
+            },
+            defaultValue: {
+                summary: null,
+            },
+            category: 'slots',
+        },
+    },
+    keySlot: {
+        name: 'copy',
+        description: 'Slot for key.',
+        defaultValue: null,
+        table: {
+            type: {
+                summary: null,
+            },
+            defaultValue: {
+                summary: null,
+            },
+            category: 'slots',
+        },
+    },
+    extraSlot: {
+        name: 'extra',
+        description: 'Slot for right space of value.',
+        defaultValue: null,
+        table: {
+            type: {
+                summary: null,
+            },
+            defaultValue: {
+                summary: null,
+            },
+            category: 'slots',
+        },
+    },
+});

--- a/src/data-display/tables/definition-table/story-helper.ts
+++ b/src/data-display/tables/definition-table/story-helper.ts
@@ -1,0 +1,104 @@
+import { ArgTypes } from '@storybook/addons';
+import { DEFINITION_TABLE_STYLE_TYPE } from '@/data-display/tables/definition-table/config';
+
+export const getDefinitionTableArgTypes = (): ArgTypes => ({
+    fields: {
+        name: 'fields',
+        type: { name: 'array' },
+        description: 'Fields of definition table.',
+        defaultValue: [
+            { label: 'Id', name: 'collector_id' },
+            { label: 'Name', name: 'name' },
+            { label: 'Provider', name: 'provider' },
+        ],
+        table: {
+            type: {
+                summary: 'array',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: '[]',
+            },
+        },
+        control: {
+            type: 'object',
+        },
+    },
+    data: {
+        name: 'data',
+        type: { name: 'object' },
+        description: 'Data object of definition table.',
+        defaultValue: {
+            collector_id: 'collector-6746d641c98b',
+            name: 'collector name',
+            provider: 'aws',
+        },
+        table: {
+            type: {
+                summary: 'object',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: 'undefined',
+            },
+        },
+        control: {
+            type: 'object',
+        },
+    },
+    loading: {
+        name: 'loading',
+        type: { name: 'boolean' },
+        description: 'Loading.',
+        defaultValue: false,
+        table: {
+            type: {
+                summary: 'boolean',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: false,
+            },
+        },
+        control: {
+            type: 'boolean',
+        },
+    },
+    skeletonRows: {
+        name: 'skeletonRows',
+        type: { name: 'number' },
+        description: 'Rows of skeletons',
+        defaultValue: 5,
+        table: {
+            type: {
+                summary: 'number',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: 5,
+            },
+        },
+        control: {
+            type: 'number',
+        },
+    },
+    styleType: {
+        name: 'styleType',
+        type: { name: 'string' },
+        description: `Box style types. ${Object.values(DEFINITION_TABLE_STYLE_TYPE)} are available.`,
+        defaultValue: DEFINITION_TABLE_STYLE_TYPE.primary,
+        table: {
+            type: {
+                summary: 'string',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: `"${DEFINITION_TABLE_STYLE_TYPE.primary}"`,
+            },
+        },
+        control: {
+            type: 'select',
+            options: Object.values(DEFINITION_TABLE_STYLE_TYPE),
+        },
+    },
+});

--- a/src/data-display/tables/definition-table/type.ts
+++ b/src/data-display/tables/definition-table/type.ts
@@ -1,4 +1,5 @@
 import { DefinitionProps } from '@/data-display/tables/definition-table/definition/type';
+import { DEFINITION_TABLE_STYLE_TYPE } from '@/data-display/tables/definition-table/config';
 
 export interface DefinitionData {
     [key: string]: any;
@@ -7,8 +8,10 @@ export interface DefinitionData {
 export interface DefinitionTableProps {
     fields: DefinitionField[];
     data?: DefinitionData;
-    loading: boolean;
-    skeletonRows: number;
+    loading?: boolean;
+    skeletonRows?: number;
+    disableCopy?: boolean;
+    styleType?: DEFINITION_TABLE_STYLE_TYPE;
 }
 
 export type DefinitionField = Omit<DefinitionProps, 'data'>

--- a/src/inputs/anchors/PAnchor.vue
+++ b/src/inputs/anchors/PAnchor.vue
@@ -15,6 +15,7 @@
                     <p-i name="ic_external-link"
                          height="1em" width="1em"
                          color="inherit"
+                         class="external-icon"
                     />
                 </slot>
             </a>
@@ -87,14 +88,17 @@ export default defineComponent<Props>({
 
 <style lang="postcss">
 .p-anchor {
-    @apply cursor-pointer inline-flex items-center;
-
+    @apply cursor-pointer inline-block;
+    vertical-align: middle;
+    line-height: inherit;
     .text {
-        margin-right: 2px;
+        font-weight: inherit;
         font-size: inherit;
         color: inherit;
-        font-weight: 400;
-        white-space: nowrap;
+        word-break: break-all;
+    }
+    .external-icon {
+        margin-left: 2px;
     }
     &.disabled {
         @apply text-gray-400;

--- a/src/others/console/text-list/PTextList.vue
+++ b/src/others/console/text-list/PTextList.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="p-text-list">
+    <span class="p-text-list">
         <component :is="component" v-for="(item, i) in displayItems"
                    :key="i" class="list-item"
                    :href="getHref(item, i)"
@@ -12,7 +12,7 @@
                 <span class="delimiter" v-html="delimiter" />
             </slot>
         </component>
-    </div>
+    </span>
 </template>
 
 <script lang="ts">
@@ -87,8 +87,10 @@ export default {
 <style lang="postcss">
 .p-text-list {
     line-height: 1.8;
-    .list-item.p-anchor:hover {
-        @apply underline text-secondary cursor-pointer;
+    .list-item {
+        .p-anchor:hover {
+            @apply underline text-secondary cursor-pointer;
+        }
     }
     .delimiter {
         white-space: pre;


### PR DESCRIPTION
### 작업 개요
- definition table 컴포넌트에 반응형 스타일, styleType, disableCopy props 추가
- 슬롯 추가(key, extra)
- 리팩토링

### 작업 상세 내용
![image](https://user-images.githubusercontent.com/26986739/121459427-33950f80-c9e6-11eb-9b0c-0952934aeceb.png)
![image](https://user-images.githubusercontent.com/26986739/121460014-36dccb00-c9e7-11eb-91d6-7f1c82c1675e.png)
![image](https://user-images.githubusercontent.com/26986739/121460049-43f9ba00-c9e7-11eb-869f-cec682e6fe9d.png)




