### PR TITLE
refactor: PSelectDropdown

### DIFF
--- a/src/inputs/dropdown/select-dropdown/PSelectDropdown.stories.ts
+++ b/src/inputs/dropdown/select-dropdown/PSelectDropdown.stories.ts
@@ -18,7 +18,7 @@ export default {
 export const defaultCase = () => ({
     components: { PSelectDropdown },
     template: `
-    <div>
+    <div style="height: 20rem">
       <PSelectDropdown :invalid="invalidState" v-model="selectItem" :items="items"></PSelectDropdown>
       <p>select item : {{selectItem}}</p>
     </div>
@@ -27,7 +27,7 @@ export const defaultCase = () => ({
         invalidState: { default: boolean('invalid', false) },
     },
     setup() {
-        const selectItem = ref('init');
+        const selectItem = ref('one');
         const items = [
             { type: 'item', label: 'one', name: 'one' },
             { type: 'item', label: 'two', name: 'two' },

--- a/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
@@ -1,37 +1,80 @@
 <template>
-    <p-dropdown-menu-btn
-        class="p-select-dropdown"
-        :class="invalidClass"
-        :menu="items"
-        :auto-height="autoHeight"
-        :disabled="disabled"
-        :loading="loading"
-        :use-custom-style="useCustomStyle"
-        :show-popup.sync="proxyShowPopup"
-        @select="changSelectItem"
-        @openMenu="$emit('openMenu')"
-    >
-        <template v-for="(_, slot) of $scopedSlots" v-slot:[slot]="scope">
-            <slot :name="slot" v-bind="scope" />
-        </template>
-        <template v-if="!$scopedSlots.default" #default>
-            {{ selectItemLabel }}
-        </template>
-    </p-dropdown-menu-btn>
+    <div v-click-outside="onClickOutside" class="p-select-dropdown">
+        <div ref="dropdownButtonRef"
+             class="dropdown-button"
+             :class="{'button-only': buttonOnly, 'invalid': invalid}"
+        >
+            <p-button v-if="!buttonOnly"
+                      :disabled="disabled"
+                      :tabindex="-1"
+                      class="menu-button"
+                      :class="{active: popup, hovered: mouseover}"
+                      :style-type="buttonStyleType"
+                      @click="onClick"
+                      @mouseover="onMouseOver"
+                      @mouseout="onMouseOut"
+            >
+                <slot name="default">
+                    {{ selectItemLabel }}
+                </slot>
+            </p-button>
+            <p-icon-button :name="buttonIcon || (popup ? 'ic_arrow_top' : 'ic_arrow_bottom')"
+                           color="inherit transparent"
+                           :class="{active: popup, hovered: mouseover}"
+                           :style-type="buttonStyleType"
+                           :disabled="disabled"
+                           :outline="true"
+                           shape="square"
+                           @click="onClick"
+                           @mouseenter="onMouseOver"
+                           @mouseleave="onMouseOut"
+            />
+        </div>
+        <p-context-menu v-if="popup"
+                        class="menu-ctx"
+                        :menu="items"
+                        :loading="loading"
+                        :auto-height="autoHeight"
+                        :use-custom-style="useCustomStyle"
+                        :position="position"
+                        :offset-top="offsetTop"
+                        :width="width"
+                        :height="height"
+                        @select="onSelectMenu"
+        >
+            <template v-for="(_, slot) of menuSlots" v-slot:[slot]="scope">
+                <slot :name="`menu-${slot}`" v-bind="scope" />
+            </template>
+        </p-context-menu>
+    </div>
 </template>
 
 <script lang="ts">
-import { groupBy } from 'lodash';
+import { groupBy, reduce } from 'lodash';
+import vClickOutside from 'v-click-outside';
+
 import {
     computed, toRefs, watch, reactive,
 } from '@vue/composition-api';
-import PDropdownMenuBtn from '@/inputs/dropdown/dropdown-menu-btn/PDropdownMenuBtn.vue';
+
+import PContextMenu from '@/inputs/context-menu/PContextMenu.vue';
+import PButton from '@/inputs/buttons/button/PButton.vue';
+import PIconButton from '@/inputs/buttons/icon-button/PIconButton.vue';
+
 import { SelectDropdownProps } from '@/inputs/dropdown/select-dropdown/type';
 import { makeProxy } from '@/util/composition-helpers';
+import { ICON_BUTTON_STYLE_TYPE } from '@/inputs/buttons/icon-button/type';
 
 export default {
     name: 'PSelectDropdown',
-    components: { PDropdownMenuBtn },
+    directives: {
+        clickOutside: vClickOutside.directive,
+    },
+    components: {
+        PIconButton,
+        PButton,
+        PContextMenu,
+    },
     model: {
         prop: 'selectItem',
     },
@@ -76,10 +119,43 @@ export default {
             type: Boolean,
             default: false,
         },
+        buttonOnly: {
+            type: Boolean,
+            default: false,
+        },
+        buttonStyleType: {
+            type: String,
+            default: undefined,
+            validator: (value) => {
+                if (value === undefined) return true;
+                return Object.keys(ICON_BUTTON_STYLE_TYPE).includes(value as any);
+            },
+        },
+        buttonIcon: {
+            type: String,
+            default: undefined,
+        },
     },
-    setup(props: SelectDropdownProps, { emit }) {
+    setup(props: SelectDropdownProps, { emit, slots }) {
         const state = reactive({
             proxyShowPopup: makeProxy('showPopup', props, emit),
+            dropdownButtonRef: null as HTMLElement | null,
+            popup: false,
+            width: 0,
+            height: 0,
+            offsetTop: 0,
+            position: null as any,
+            menuSlots: computed(() => reduce(slots, (res, d, name) => {
+                if (name.startsWith('menu-')) res[`${name.substring(5)}`] = d;
+                return res;
+            }, {})),
+            buttonSlots: computed(() => reduce(slots, (res, d, name) => {
+                if (name.startsWith('button-') || name === 'button-default') {
+                    res[`${name.substring(7)}`] = d;
+                }
+                return res;
+            }, {})),
+            mouseover: false,
         });
         const selectItemLabel = computed(() => {
             if (props.indexMode) {
@@ -92,24 +168,61 @@ export default {
             }
             return props.placeholder;
         });
-        const changSelectItem = (value, index) => {
-            if (props.indexMode) {
-                emit('input', index);
-                emit('onSelected', index);
-            } else {
-                emit('input', value);
-                emit('onSelected', value);
+
+        /* util */
+        const setCustomStyle = () => {
+            if (state.dropdownButtonRef) {
+                const winHeight = window.innerHeight;
+                const rects: any = state.dropdownButtonRef?.getBoundingClientRect();
+                let position = 'bottom';
+                if (winHeight * 0.9 > rects.top) position = 'top';
+
+                state.position = position;
+                state.offsetTop = rects.top;
+                state.width = rects.width;
+                state.height = rects.height;
             }
         };
-        const invalidClass = computed(() => ({ 'is-invalid-btn': props.invalid }));
-        watch(() => props.showPopup, (after, before) => {
-            if (!after) state.proxyShowPopup = false;
+
+        /* event */
+        const onSelectMenu = (value, index) => {
+            if (props.indexMode) {
+                emit('input', index);
+                emit('onSelected', index); // todo: deprecated
+            } else {
+                emit('input', value);
+                emit('onSelected', value); // todo: deprecated
+            }
+            state.popup = false;
+        };
+        const onClick = () => {
+            state.popup = !state.popup;
+            state.proxyShowPopup = false;
+            if (props.useCustomStyle) setCustomStyle();
+        };
+        const onMouseOver = () => {
+            if (!props.disabled) state.mouseover = true;
+        };
+        const onMouseOut = () => {
+            if (!props.disabled) state.mouseover = false;
+        };
+        const onClickOutside = (): void => {
+            state.popup = false;
+        };
+
+        watch(() => props.showPopup, (showPopup) => {
+            if (!showPopup) state.proxyShowPopup = false;
         });
+
         return {
             ...toRefs(state),
             selectItemLabel,
-            changSelectItem,
-            invalidClass,
+            onClickOutside,
+            onSelectMenu,
+            onClick,
+            onMouseOver,
+            onMouseOut,
+            setCustomStyle,
         };
     },
 };
@@ -117,19 +230,61 @@ export default {
 
 <style lang="postcss">
 .p-select-dropdown {
-    .p-dropdown-btn {
-        width: 100%;
-    }
-    &.is-invalid-btn .p-dropdown-btn {
-        .menu-btn.p-button {
-            @apply border border-alert;
+    position: relative;
+
+    .dropdown-button {
+        display: inline-flex;
+        min-width: 6.5rem;
+
+        &.button-only {
+            min-width: unset;
         }
-        .p-icon-button.p-button, .p-icon-button.p-button.active, .p-icon-button.p-button.hovered {
-            @apply border border-alert;
+        &.invalid {
+            .p-button {
+                @apply border border-alert;
+            }
+            .p-icon-button.p-button, .p-icon-button.p-button.active, .p-icon-button.p-button.hovered {
+                @apply border border-alert;
+            }
         }
-    }
-    .p-dropdown-btn .menu-btn.p-button.active {
-        @apply text-gray-900;
+
+        .menu-button {
+            @apply border-gray-300 text-gray-900 px-2 justify-start text-left flex-grow font-normal;
+            width: auto;
+            min-width: unset;
+            margin-right: -1px;
+            border-radius: 2px 0 0 2px;
+            &:not(.active).hovered {
+                @apply border-gray-900;
+            }
+            &.active {
+                @apply border-secondary text-secondary;
+            }
+            &.disabled {
+                @apply bg-gray-100 text-gray-300;
+            }
+        }
+
+        .p-icon-button.outline {
+            @apply flex-shrink-0 border-gray-300;
+            &:not(.active).hovered {
+                @apply border-gray-900;
+            }
+            &:not(.disabled):hover {
+                border-color: unset;
+                background-color: unset;
+                color: unset;
+            }
+            &.disabled {
+                @apply text-gray-300;
+            }
+            &.active {
+                @apply border-secondary text-secondary;
+                &:hover {
+                    @apply border-secondary text-secondary;
+                }
+            }
+        }
     }
 }
 </style>

--- a/src/inputs/dropdown/select-dropdown/type.ts
+++ b/src/inputs/dropdown/select-dropdown/type.ts
@@ -1,5 +1,9 @@
 import { MenuItem } from '@/inputs/context-menu/type';
 
+enum BUTTON_STYLE_TYPE {
+    'primary-dark' = 'primary-dark'
+}
+
 export interface SelectDropdownStateType {
     items: MenuItem[];
     invalid: boolean;
@@ -10,6 +14,9 @@ export interface SelectDropdownStateType {
     placeholder: string;
     useCustomStyle: boolean;
     showPopup: boolean;
+    buttonOnly: boolean;
+    buttonStyleType?: keyof BUTTON_STYLE_TYPE;
+    buttonIcon: string;
 }
 
 export interface SelectDropdownSyncStateType {


### PR DESCRIPTION
### 작업 개요
PSelectDropdown에서 PDropdownMenuBtn을 사용하던 것을 삭제 (PDropdownMenuBtn 컴포넌트는 그대로 있음!)

### 작업 분류
- [ ] 버그 수정
- [ ] 신규 기능
- [x] 프로젝트 구조 변경

### 작업 상세 내용
- 일부 클래스명 수정(btn > button, is-invalid-btn > invalid)
- 거의 대부분 그대로 옮겼습니다.

### 생각해볼 문제
- emit event를 할 때 input과 onSelected 두 개를 같이 사용하는데, input만 남겼으면 좋겠습니다. (콘솔에서 사용하는 곳이 있어서 차차 수정해야 할듯)
- 전반적인 리팩토링 필요할듯 (디자인, 이벤트 처리 등)
