### PR TITLE
feat: add auto hide in context menu custom style hook

### DIFF
--- a/src/feedbacks/modals/button-modal/PButtonModal.stories.mdx
+++ b/src/feedbacks/modals/button-modal/PButtonModal.stories.mdx
@@ -13,7 +13,7 @@ import faker from 'faker';
         type: 'figma',
         url: 'https://www.figma.com/file/wq4wSowBcADBuUrMEZLz6i/SpaceONE-Console-Design?node-id=7654%3A182002',
     },
-}} component={PButtonModal} argTypes={{
+}} argTypes={{
     size: {
         name: 'size',
         type: { name: 'string' },
@@ -355,37 +355,16 @@ export const Template = (args, {argTypes} ) => ({
                 <p-button :styleType="themeColor" @click="launchModal">Launch a modal</p-button>
                 <p-button-modal
                                 :visible.sync="_visible"
-                                :show-popup.sync="isScrolling"
                                 @close="closeModal"
                 >
                     <template #body>
-                        <p-dropdown-menu-btn
-                            :menu="menu"
-                            :use-custom-style="useCustomStyle"
-                            :auto-height="autoHeight"
-                            :show-popup.sync="isScrolling"
-                        >
-                            dropdown menu btn
-                        </p-dropdown-menu-btn>
-                        <p>{{contents}}</p>
                         <p-select-dropdown
                             :items="items"
                             v-model="selectItem"
-                            :use-custom-style="useCustomStyle"
-                            :auto-height="autoHeight"
-                            :show-popup.sync="isScrolling"
+                            use-fixed-menu-style
                         >
                            select dropdown (default)
                         </p-select-dropdown>
-                        <p>{{contents}}</p>
-                        <p-dropdown-menu-btn
-                            :menu="menu"
-                            :use-custom-style="useCustomStyle"
-                            :auto-height="autoHeight"
-                            :show-popup.sync="isScrolling"
-                        >
-                            dropdown menu btn
-                        </p-dropdown-menu-btn>
                         <p>{{contents}}</p>
                     </template>
                 </p-button-modal>
@@ -419,9 +398,6 @@ export const Template = (args, {argTypes} ) => ({
                     type: 'item', label: 'Remove', name: 'remove', disabled: true,
                 },
             ],
-            autoHeight: true,
-            useCustomStyle: true,
-            isScrolling: false,
             items: [
                 { type: 'item', label: 'one', name: 'one' },
                 { type: 'item', label: 'two', name: 'two' },
@@ -453,7 +429,7 @@ export const Template = (args, {argTypes} ) => ({
                 { type: 'item', label: 'four', name: 'four' },
                 { type: 'item', label: 'five', name: 'five' },
                 { type: 'item', label: 'six', name: 'six' },
-            ]
+            ],
         });
         const launchModal = () => {
             state._visible = true;

--- a/src/feedbacks/modals/button-modal/PButtonModal.vue
+++ b/src/feedbacks/modals/button-modal/PButtonModal.vue
@@ -23,9 +23,7 @@
                                            @click.stop="onCloseClick"
                             />
                         </h3>
-                        <div v-if="bodyVisible" class="modal-body" :class="allBodyClass"
-                             @scroll="onScroll"
-                        >
+                        <div v-if="bodyVisible" class="modal-body" :class="allBodyClass">
                             <slot name="body" />
                         </div>
                         <div v-if="footerVisible" class="modal-footer">
@@ -82,10 +80,6 @@ import '../modal.pcss';
 import PIconButton from '@/inputs/buttons/icon-button/PIconButton.vue';
 import PLottie from '@/foundation/lottie/PLottie.vue';
 
-const documentEventMount = (eventName: string, func: any) => {
-    onMounted(() => document.addEventListener(eventName, func));
-    onUnmounted(() => document.removeEventListener(eventName, func));
-};
 
 export default {
     name: 'PButtonModal',
@@ -152,10 +146,6 @@ export default {
             type: Boolean,
             default: false,
         },
-        showPopup: {
-            type: Boolean,
-            default: false,
-        },
     },
     setup(props: ButtonModalProps, { emit }) {
         const state = reactive({
@@ -198,10 +188,6 @@ export default {
         const onConfirmClick = () => {
             emit('confirm');
         };
-        const onScroll = (event) => {
-            emit('update:showPopup', true);
-        };
-        documentEventMount('scroll', onScroll);
 
         return {
             ...toRefs(state),
@@ -213,7 +199,6 @@ export default {
             onCloseClick,
             onCancelClick,
             onConfirmClick,
-            onScroll,
         };
     },
 };

--- a/src/feedbacks/modals/button-modal/type.ts
+++ b/src/feedbacks/modals/button-modal/type.ts
@@ -41,6 +41,4 @@ export interface ButtonModalProps {
 
     loading: boolean;
     disabled: boolean;
-
-    showPopup: boolean;
 }

--- a/src/hooks/context-menu-custom-style/index.ts
+++ b/src/hooks/context-menu-custom-style/index.ts
@@ -1,38 +1,95 @@
 import {
-    computed, ComputedRef, reactive, Ref,
+    ComponentRenderProxy,
+    computed, getCurrentInstance, onMounted, onUnmounted, reactive, watch,
 } from '@vue/composition-api';
+import { throttle } from 'lodash';
 import { Vue } from 'vue/types/vue';
+import { makeOptionalProxy } from '@/util/composition-helpers';
 
-export const useContextMenuCustomStyle = (visible: Ref<boolean>|ComputedRef<boolean>) => {
+interface ContextMenuCustomStyleProps {
+    useFixedMenuStyle?: boolean;
+    visibleMenu?: boolean;
+}
+
+const isScrollable = (ele: Element) => {
+    const hasScrollableContent = ele.scrollHeight > ele.clientHeight;
+
+    const overflowYStyle = window.getComputedStyle(ele).overflowY;
+    const isOverflowHidden = overflowYStyle.indexOf('hidden') !== -1;
+
+    return hasScrollableContent && !isOverflowHidden;
+};
+
+const getScrollableParent = (ele?: Element|null): Element => {
+    if (!ele || ele === document.body) return document.body;
+    return isScrollable(ele) ? ele : getScrollableParent(ele.parentElement);
+};
+
+export const useContextMenuCustomStyle = (
+    props: ContextMenuCustomStyleProps,
+) => {
+    const vm = getCurrentInstance() as ComponentRenderProxy;
     const state = reactive({
-        targetRef: null as Vue|HTMLElement|null,
+        proxyVisibleMenu: makeOptionalProxy('visibleMenu', vm, false),
+        targetRef: null as Vue|Element|null,
+        targetElement: computed<Element|null>(() => (state.targetRef as Vue)?.$el ?? state.targetRef),
         contextMenuStyle: computed(() => {
-            if (!visible.value || !state.targetRef) return {};
+            if (!state.proxyVisibleMenu || !state.targetRef) return {};
 
-            const winHeight = window.innerHeight;
-            const rects: any = ((state.targetRef as Vue).$el ?? state.targetRef).getBoundingClientRect();
+            const targetRects: DOMRect = state.targetElement?.getBoundingClientRect();
 
-            const contextMenuStyle: any = {
-                position: 'fixed',
+            const contextMenuStyle: Partial<CSSStyleDeclaration> = {
+                position: props.useFixedMenuStyle ? 'fixed' : 'absolute',
                 minWidth: 'auto',
                 overflowY: 'auto',
                 height: 'auto',
-                width: `${rects.width}px`,
+                minHeight: '32px',
+                width: props.useFixedMenuStyle ? `${targetRects.width}px` : '100%',
             };
 
-            if (winHeight * 0.9 > rects.top) {
-                const height = window.innerHeight - rects.top - rects.height - 12;
+            if (window.innerHeight * 0.9 > (targetRects.bottom)) {
+                const height = window.innerHeight - targetRects.bottom - 12;
                 contextMenuStyle.maxHeight = `${height < 0 ? 0 : height}px`;
-                contextMenuStyle.top = `calc(${rects.top}px + ${rects.height}px)`;
+                if (props.useFixedMenuStyle) contextMenuStyle.top = `${targetRects.bottom}px`;
+                else contextMenuStyle.top = `${targetRects.height}px`;
             } else {
-                const height = rects.top - 12;
+                const height = targetRects.top - 12;
                 contextMenuStyle.maxHeight = `${height < 0 ? 0 : height}px`;
-                contextMenuStyle.bottom = `calc(100vh - ${rects.top}px)`;
+                if (props.useFixedMenuStyle) contextMenuStyle.bottom = `${targetRects.top}px`;
+                else contextMenuStyle.bottom = `${targetRects.height}px`;
             }
 
             return contextMenuStyle;
         }),
     });
+
+    const hideMenu = throttle(() => {
+        if (state.proxyVisibleMenu) state.proxyVisibleMenu = false;
+    }, 300);
+
+
+    if (props.useFixedMenuStyle) {
+        let scrollParent: Element|undefined;
+        watch(() => state.targetElement, (targetElement) => {
+            if (targetElement) {
+                scrollParent = getScrollableParent(targetElement);
+                if (scrollParent) {
+                    scrollParent.addEventListener('scroll', hideMenu);
+                }
+            } else if (scrollParent) {
+                scrollParent.removeEventListener('scroll', hideMenu);
+            }
+        });
+
+        onMounted(() => {
+            window.addEventListener('resize', hideMenu);
+        });
+
+        onUnmounted(() => {
+            window.removeEventListener('resize', hideMenu);
+        });
+    }
+
 
     return {
         state,

--- a/src/hooks/context-menu-custom-style/story-helper.ts
+++ b/src/hooks/context-menu-custom-style/story-helper.ts
@@ -1,0 +1,22 @@
+export const getContextMenuCustomStyleArgTypes = () => {
+    return {
+        useFixedMenuStyle: {
+            name: 'useFixedMenuStyle',
+            type: { name: 'boolean' },
+            description: 'Whether to use position fixed style on menu or not. ',
+            defaultValue: false,
+            table: {
+                type: {
+                    summary: 'boolean',
+                },
+                category: 'props',
+                defaultValue: {
+                    summary: 'false',
+                },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
+    }
+}

--- a/src/inputs/context-menu/type.ts
+++ b/src/inputs/context-menu/type.ts
@@ -29,7 +29,7 @@ export interface ContextMenuProps {
     theme: keyof typeof CONTEXT_MENU_THEME;
     loading: boolean;
     autoHeight: boolean;
-    useCustomStyle: boolean;
+    useFixedMenuStyle: boolean;
     position?: CONTEXT_MENU_POSITION;
     offsetTop?: number;
     width?: number;

--- a/src/inputs/dropdown/select-dropdown/type.ts
+++ b/src/inputs/dropdown/select-dropdown/type.ts
@@ -1,26 +1,18 @@
 import { MenuItem } from '@/inputs/context-menu/type';
+import { BUTTON_STYLE } from '@/inputs/buttons/button/type';
 
-enum BUTTON_STYLE_TYPE {
-    'primary-dark' = 'primary-dark'
-}
 
-export interface SelectDropdownStateType {
-    items: MenuItem[];
-    invalid: boolean;
-    autoHeight: boolean;
-    disabled: boolean;
-    loading: boolean;
+export interface SelectDropdownProps {
+    items?: MenuItem[];
+    selectItem?: string | number;
+    invalid?: boolean;
+    disabled?: boolean;
+    loading?: boolean;
     indexMode: boolean;
-    placeholder: string;
-    useCustomStyle: boolean;
-    showPopup: boolean;
-    buttonOnly: boolean;
-    buttonStyleType?: keyof BUTTON_STYLE_TYPE;
-    buttonIcon: string;
+    placeholder?: string;
+    useFixedMenuStyle?: boolean;
+    visibleMenu?: boolean;
+    buttonOnly?: boolean;
+    buttonStyleType?: BUTTON_STYLE;
+    buttonIcon?: string;
 }
-
-export interface SelectDropdownSyncStateType {
-    selectItem: string | number;
-}
-
-export interface SelectDropdownProps extends SelectDropdownStateType, SelectDropdownSyncStateType {}

--- a/src/inputs/search/autocomplete-search/PAutocompleteSearch.stories.mdx
+++ b/src/inputs/search/autocomplete-search/PAutocompleteSearch.stories.mdx
@@ -28,6 +28,7 @@ export const Template = (args, { argTypes }) => ({
             :disable-icon="disableIcon"
             :disable-handler="disableHandler"
             :exact-mode="exactMode"
+            :use-fixed-menu-style="useFixedMenuStyle"
             @search="onSearch"
             @focus="onFocus"
             @blur="onBlur"

--- a/src/inputs/search/autocomplete-search/story-helper.ts
+++ b/src/inputs/search/autocomplete-search/story-helper.ts
@@ -1,6 +1,7 @@
 import { getSearchArgTypes } from '@/inputs/search/search/story-helper';
 import { getContextMenuArgTypes } from '@/inputs/context-menu/story-helper';
 import { ArgTypes } from '@storybook/addons';
+import { getContextMenuCustomStyleArgTypes } from '@/hooks/context-menu-custom-style/story-helper';
 
 const extraArgTypes: ArgTypes = {
     visibleMenu: {
@@ -75,6 +76,7 @@ const extraArgTypes: ArgTypes = {
             type: 'boolean',
         },
     },
+    /* events */
     onHideMenu: {
         name: 'hide-menu',
         description: 'Emitted when the menu starts to hide.',
@@ -169,5 +171,6 @@ const initContextMenuArgTypes = (): ArgTypes => {
 export const getAutocompleteSearchArgTypes = (): ArgTypes => ({
     ...initSearchArgTypes(),
     ...initContextMenuArgTypes(),
+    ...getContextMenuCustomStyleArgTypes(),
     ...extraArgTypes,
 });


### PR DESCRIPTION
### 작업 개요
- context menu custom style hook 에서 scrollable parent 를 찾아, 있는 경우에는 자동으로  context menu 를 닫아주는 기능 추가
- use custom style -> use fixed menu style 로 props 명 변경

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
selectable dropdown, autocomplete search 컴포넌트에서 use custom style -> use fixed menu style 로 props 이름을 변경했습니다.

use fixed menu style 을 true 로 주면, 아래의 기능이 동작하게 됩니다.
1. menu 가 position fixed 로 동작
2. scrollable parent 에 scroll 이벤트 발생 시, menu  자동으로 닫음 

이에 따라 button modal 에서 scroll 이벤트 관련된 동작을 모두 삭제했습니다.




