### PR TITLE
fix: add sync props to PToggleButton

### DIFF
--- a/src/inputs/buttons/toggle-button/PToggleButton.stories.mdx
+++ b/src/inputs/buttons/toggle-button/PToggleButton.stories.mdx
@@ -12,6 +12,24 @@ import { TOGGLE_BUTTON_THEME } from "@/inputs/buttons/toggle-button/config";
     }}
     component={ PToggleButton }
     argTypes={{
+        sync: {
+            name: 'sync',
+            type: { name: 'boolean' },
+            description: 'If set to true, will be watching changes in value property and overwrite the current state of the button whenever value prop changes',
+            defaultValue: false,
+            table: {
+                type: {
+                    summary: 'boolean',
+                },
+                category: 'props',
+                defaultValue: {
+                    summary: 'false',
+                },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
         value: {
             name: 'value',
             type: { name: 'boolean' },

--- a/src/inputs/buttons/toggle-button/PToggleButton.vue
+++ b/src/inputs/buttons/toggle-button/PToggleButton.vue
@@ -1,6 +1,7 @@
 <template>
     <toggle-button
         :value="value"
+        :sync="sync"
         :color="colors"
         :width="32"
         :height="16"
@@ -28,6 +29,10 @@ export default {
         ToggleButton,
     },
     props: {
+        sync: {
+            type: Boolean,
+            default: false,
+        },
         value: {
             type: Boolean,
             default: false,


### PR DESCRIPTION
### 작업 개요
PToggleButton에서 제가 없애버렸던 sync props를 되살렸습니다.

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
