### PR TITLE
feat: add walk tree data method to tree and refactor some methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3701,12 +3701,6 @@
             "node-releases": "^1.1.69"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001173",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001173.tgz",
-          "integrity": "sha512-R3aqmjrICdGCTAnSXtNyvWYMK3YtV5jwudbq0T7nN9k4kmE4CBuwPqyJ+KBzepSTh0huivV2gLbSMEzTTmfeYw==",
-          "dev": true
-        },
         "core-js-compat": {
           "version": "3.8.2",
           "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.8.2.tgz",
@@ -15065,9 +15059,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001154",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001154.tgz",
-      "integrity": "sha512-y9DvdSti8NnYB9Be92ddMZQrcOe04kcQtcxtBx4NkB04+qZ+JUWotnXBJTmxlKudhxNTQ3RRknMwNU2YQl/Org==",
+      "version": "1.0.30001240",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001240.tgz",
+      "integrity": "sha512-nb8mDzfMdxBDN7ZKx8chWafAdBp5DAAlpWvNyUGe5tcDWd838zpzDN3Rah9cjCqhfOKkrvx40G2SDtP0qiWX/w==",
       "dev": true
     },
     "capital-case": {
@@ -22562,9 +22556,9 @@
       "dev": true
     },
     "he-tree-vue": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/he-tree-vue/-/he-tree-vue-2.0.7.tgz",
-      "integrity": "sha512-99qv2/5w1iXqeDaILpl8zO4hkU39xK2l8uUDz4Ll6Yd60L21dIvtlMpxKLIpIxtkPUnM4avm+ZiWRMw726yHPw==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/he-tree-vue/-/he-tree-vue-2.0.10.tgz",
+      "integrity": "sha512-tD1/OD/eLzUkqSDi0ztr5aAyw/MhtOvpQXB7siUTxCQ/wx3Xky8Y+5AwMeMXuxqFYTUH7os43AO3HGr2umBKtw==",
       "requires": {
         "@babel/runtime": "^7.7.7",
         "draggable-helper": "^5.0.6",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "ejs": "^3.1.5",
     "faker": "^5.1.0",
     "fuse.js": "^3.4.6",
-    "he-tree-vue": "^2.0.7",
+    "he-tree-vue": "^2.0.10",
     "highlight.js": "^10.0.2",
     "lodash": "^4.17.15",
     "lottie-web": "^5.5.9",

--- a/src/data-display/tree/PTree.stories.mdx
+++ b/src/data-display/tree/PTree.stories.mdx
@@ -502,18 +502,19 @@ You can use tree methods by tree instance that passed by `init` event. <br/>
 |toggleNode| It toggles a node that found by path. |
 |getNodeParentByPath| It returns parent node by path. |
 |getNodeByPath| It returns node by path. |
+|walkTreeData| Iterate tree nodes <br/> Arguments: (treeData: TreeNode[], handler: Function, options: {}) <br/> Handler: (node: TreeNode, index: number, parent: TreeNode(or null), path: number[]) <br/> - return false: stop walk <br/> - return 'skip children' <br/> - return 'skip siblings' <br/> Options: {Boolean} reverse|
 
 ```typescript
 interface Tree<T=any> {
-    fetchData: (node?: TreeNode<T>|null) => Promise<TreeNode<T>[]>;
+     fetchData: (node?: TreeNode<T>|null) => Promise<TreeNode<T>[]>;
     changeSelectState: (node: TreeNode<T>, path: number[], value?: boolean) => void;
     addNode: (data: T[]|T) => void;
     findNode: (predicate: Predicate<T>) => TreeNode<T>|null;
     fetchAndFindNode: (predicates: Predicate<T>[]) => Promise<{node: TreeNode<T>|null; path: number[]}>;
     fetchAndFindNodes: (predicateList: Predicate<T>[][]) => Promise<{node: TreeNode<T>; path: number[]}[]>;
     resetSelect: () => void;
-    getAllNodes: (node?: TreeNode<T>|null, nodes?: TreeNode<T>[]) => TreeNode<T>[];
-    getAllItems: (node?: TreeNode<T>|null, path?: number[]) => TreeItem<T>[];
+    getAllNodes: (node?: TreeNode<T>|null) => TreeNode<T>[];
+    getAllItems: (node?: TreeNode<T>|null) => TreeItem<T>[];
     deleteNodeByPath: (path: number[]) => void;
     deleteNode: (predicate: Predicate<T>) => void;
     addChildNodeByPath: (path: number[], data: T[]|T, unfold?: boolean) => void;
@@ -523,6 +524,7 @@ interface Tree<T=any> {
     // he tree vue api
     getNodeParentByPath: (path: number[]) => TreeNode<T>|null;
     getNodeByPath: (path: number[]) => TreeNode<T>;
+    walkTreeData: (treeData: TreeNode<T>[], callback: walkTreeDataCallback, options?: {reverse: boolean}) => void;
 }
 
 interface Predicate<T=any> {

--- a/src/data-display/tree/PTree.stories.mdx
+++ b/src/data-display/tree/PTree.stories.mdx
@@ -502,7 +502,8 @@ You can use tree methods by tree instance that passed by `init` event. <br/>
 |toggleNode| It toggles a node that found by path. |
 |getNodeParentByPath| It returns parent node by path. |
 |getNodeByPath| It returns node by path. |
-|walkTreeData| Iterate tree nodes <br/> Arguments: (treeData: TreeNode[], handler: Function, options: {}) <br/> Handler: (node: TreeNode, index: number, parent: TreeNode(or null), path: number[]) <br/> - return false: stop walk <br/> - return 'skip children' <br/> - return 'skip siblings' <br/> Options: {Boolean} reverse|
+|walkTreeData| Iterate tree nodes <br/> Arguments: (treeData: TreeNode[](or null), handler: Function, options: {}) <br/> Handler: (node: TreeNode, index: number, parent: TreeNode(or null), path: number[]) <br/> - return false: stop walk <br/> - return 'skip children' <br/> - return 'skip siblings' <br/> Options: {Boolean} reverse|
+|cloneTreeData| Clones tree nodes <br> options - afterNodeCreated: (newNode, {oldNode: node, index, parent, path}) |
 
 ```typescript
 interface Tree<T=any> {
@@ -524,7 +525,8 @@ interface Tree<T=any> {
     // he tree vue api
     getNodeParentByPath: (path: number[]) => TreeNode<T>|null;
     getNodeByPath: (path: number[]) => TreeNode<T>;
-    walkTreeData: (treeData: TreeNode<T>[], callback: walkTreeDataCallback, options?: {reverse: boolean}) => void;
+    walkTreeData: (treeData: TreeNode<T>[]|null, callback: walkTreeDataCallback, options?: {reverse: boolean}) => void;
+    cloneTreeData(treeData: TreeNode<T>[]|null, options?: cloneTreeDataOptions): TreeNode[];
 }
 
 interface Predicate<T=any> {

--- a/src/data-display/tree/PTree.vue
+++ b/src/data-display/tree/PTree.vue
@@ -66,7 +66,7 @@
 <script lang="ts">
 /* eslint-disable no-await-in-loop */
 import {
-    Tree as TreeComp, Fold, Draggable, Store, Tree as OriginTree, walkTreeData,
+    Tree as OriginTree, Fold, Draggable, Store, walkTreeData, walkTreeDataCallback, cloneTreeDataOptions, cloneTreeData,
 } from 'he-tree-vue';
 import {
     computed, defineComponent, onMounted, reactive, toRefs, watch,
@@ -109,7 +109,7 @@ export default defineComponent<Props>({
     components: {
         PTextInput,
         PI,
-        Tree: ((TreeComp as any).mixPlugins([Fold, Draggable]) as any),
+        Tree: ((OriginTree as any).mixPlugins([Fold, Draggable]) as any),
     },
     directives: { focus },
     props: {
@@ -508,7 +508,7 @@ export default defineComponent<Props>({
                     if (Array.isArray(data)) {
                         parent.children = parent.children.concat(data.map(d => getDefaultNode(d)));
                     } else {
-                        parent.children.push(getDefaultNode(data));
+                        parent.children = [...parent.children, getDefaultNode(data)];
                     }
                     if (unfold) parent.$folded = false;
                 } else {
@@ -522,7 +522,6 @@ export default defineComponent<Props>({
 
             const target = state.treeRef.getNodeByPath(path);
             if (!target) return;
-
             target.data = data;
         };
 
@@ -559,12 +558,21 @@ export default defineComponent<Props>({
                 })();
             },
             getNodeParentByPath(path: number[]) {
-                return state.treeRef.getNodeParentByPath(path) || null;
+                return state.treeRef?.getNodeParentByPath(path) || null;
             },
             getNodeByPath(path: number[]) {
-                return state.treeRef.getNodeByPath(path) || null;
+                return state.treeRef?.getNodeByPath(path) || null;
             },
-            walkTreeData,
+            walkTreeData(treeData: TreeNode[]|null, handler: walkTreeDataCallback, options?: {reverse: boolean}) {
+                if (!state.treeRef) return;
+
+                walkTreeData(treeData === null ? state.treeData : treeData, handler, options);
+            },
+            cloneTreeData(treeData: TreeNode[]|null, options: cloneTreeDataOptions): TreeNode[] {
+                if (!state.treeRef) return [];
+
+                return cloneTreeData(treeData === null ? state.treeData : treeData, options) as TreeNode[];
+            },
         };
 
         onMounted(() => {

--- a/src/data-display/tree/PTree.vue
+++ b/src/data-display/tree/PTree.vue
@@ -66,7 +66,7 @@
 <script lang="ts">
 /* eslint-disable no-await-in-loop */
 import {
-    Tree as TreeComp, Fold, Draggable, Store, Tree as OriginTree,
+    Tree as TreeComp, Fold, Draggable, Store, Tree as OriginTree, walkTreeData,
 } from 'he-tree-vue';
 import {
     computed, defineComponent, onMounted, reactive, toRefs, watch,
@@ -468,31 +468,22 @@ export default defineComponent<Props>({
             setSelectItems(foundItems);
             return foundItems;
         };
-        const getAllNodes = (node?: TreeNode|null, nodes: TreeNode[] = []): TreeNode[] => {
-            const children: any[] = node?.children || state.treeData;
-            children.forEach((d) => {
-                nodes.push(d);
-                if (d.children && d.children.length) getAllNodes(d, nodes);
+        const getAllNodes = (_node?: TreeNode|null): TreeNode[] => {
+            if (!state.treeRef) return [];
+
+            const items: TreeNode[] = [];
+            walkTreeData(_node?.children || state.treeData, (node) => {
+                items.push(node as TreeNode);
             });
-            return nodes;
+            return items;
         };
 
-        const getAllItems = (node?: TreeNode|null, _path: number[] = []): TreeItem[] => {
-            const children: TreeNode[] = node?.children || state.treeData;
-            let items: TreeItem[] = [];
+        const getAllItems = (_node?: TreeNode|null): TreeItem[] => {
+            if (!state.treeRef) return [];
 
-            children.forEach((d, i) => {
-                const path = [..._path];
-                path.push(i);
-
-                const data: TreeItem = {
-                    path,
-                    node: d,
-                };
-                items.push(data);
-                if (d.children && d.children.length) {
-                    items = items.concat(getAllItems(d, path));
-                }
+            const items: TreeItem[] = [];
+            walkTreeData(_node?.children || state.treeData, (node, index, parent, path) => {
+                items.push({ node: node as TreeNode, path });
             });
             return items;
         };
@@ -573,6 +564,7 @@ export default defineComponent<Props>({
             getNodeByPath(path: number[]) {
                 return state.treeRef.getNodeByPath(path) || null;
             },
+            walkTreeData,
         };
 
         onMounted(() => {

--- a/src/data-display/tree/type.ts
+++ b/src/data-display/tree/type.ts
@@ -1,4 +1,4 @@
-import { Node } from 'he-tree-vue';
+import { Node, walkTreeDataCallback } from 'he-tree-vue';
 
 export interface TreeNode<T=any> extends Node {
     data: T;
@@ -66,8 +66,8 @@ export interface Tree<T=any> {
     fetchAndFindNode: (predicates: Predicate<T>[]) => Promise<{node: TreeNode<T>|null; path: number[]}>;
     fetchAndFindNodes: (predicateList: Predicate<T>[][]) => Promise<{node: TreeNode<T>; path: number[]}[]>;
     resetSelect: () => void;
-    getAllNodes: (node?: TreeNode<T>|null, nodes?: TreeNode<T>[]) => TreeNode<T>[];
-    getAllItems: (node?: TreeNode<T>|null, path?: number[]) => TreeItem<T>[];
+    getAllNodes: (node?: TreeNode<T>|null) => TreeNode<T>[];
+    getAllItems: (node?: TreeNode<T>|null) => TreeItem<T>[];
     deleteNodeByPath: (path: number[]) => void;
     deleteNode: (predicate: Predicate<T>) => void;
     addChildNodeByPath: (path: number[], data: T[]|T, unfold?: boolean) => void;
@@ -77,4 +77,5 @@ export interface Tree<T=any> {
     // he tree vue api
     getNodeParentByPath: (path: number[]) => TreeNode<T>|null;
     getNodeByPath: (path: number[]) => TreeNode<T>;
+    walkTreeData: (treeData: TreeNode<T>[], callback: walkTreeDataCallback, options?: {reverse: boolean}) => void;
 }

--- a/src/data-display/tree/type.ts
+++ b/src/data-display/tree/type.ts
@@ -1,4 +1,4 @@
-import { Node, walkTreeDataCallback } from 'he-tree-vue';
+import { cloneTreeDataOptions, Node, walkTreeDataCallback } from 'he-tree-vue';
 
 export interface TreeNode<T=any> extends Node {
     data: T;
@@ -77,5 +77,6 @@ export interface Tree<T=any> {
     // he tree vue api
     getNodeParentByPath: (path: number[]) => TreeNode<T>|null;
     getNodeByPath: (path: number[]) => TreeNode<T>;
-    walkTreeData: (treeData: TreeNode<T>[], callback: walkTreeDataCallback, options?: {reverse: boolean}) => void;
+    walkTreeData: (treeData: TreeNode<T>[]|null, handler: walkTreeDataCallback, options?: {reverse: boolean}) => void;
+    cloneTreeData(treeData: TreeNode<T>[]|null, options?: cloneTreeDataOptions): TreeNode[];
 }


### PR DESCRIPTION
### 작업 개요
- tree 컴포넌트에  walk tree data 메소드 추가
- get all nodes, get all items 의 복잡한 로직 리팩토링. 내부 로직을 walk tree data 를 사용하도록 변경함.
- tree 컴포넌트에서 addChildNodeByPath 후 추가한 아이템 레퍼런스를 찾지 못하는 버그 수정

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경


