### PR TITLE
feat: add disabled border-color to PSelectCard

### DIFF
--- a/src/inputs/select-card/PSelectCard.vue
+++ b/src/inputs/select-card/PSelectCard.vue
@@ -134,7 +134,7 @@ export default defineComponent<Props>({
         @apply border-secondary text-secondary;
     }
     &.disabled {
-        @apply text-gray-400;
+        @apply border-gray-200 text-gray-400;
         cursor: not-allowed;
     }
     .marker {


### PR DESCRIPTION
### 작업 개요
PSelectCard disabled 일경우 border-color

### 작업 상세 내용
- PSelectCard  selected 와 disabled를 동시에 적용할 경우 border-color가 selected-border(border-secondary)로 적용되어 수정


