### PR TITLE
feat: add icon color to select card and error icon color to lazy img

### DIFF
--- a/src/data-display/tree/PTree.stories.mdx
+++ b/src/data-display/tree/PTree.stories.mdx
@@ -503,7 +503,7 @@ You can use tree methods by tree instance that passed by `init` event. <br/>
 |getNodeParentByPath| It returns parent node by path. |
 |getNodeByPath| It returns node by path. |
 |walkTreeData| Iterate tree nodes <br/> Arguments: (treeData: TreeNode[](or null), handler: Function, options: {}) <br/> Handler: (node: TreeNode, index: number, parent: TreeNode(or null), path: number[]) <br/> - return false: stop walk <br/> - return 'skip children' <br/> - return 'skip siblings' <br/> Options: {Boolean} reverse|
-|cloneTreeData| Clones tree nodes <br> options - afterNodeCreated: (newNode, {oldNode: node, index, parent, path}) |
+|cloneTreeData| Clones tree nodes <br/> options - afterNodeCreated: (newNode, {oldNode: node, index, parent, path}) |
 
 ```typescript
 interface Tree<T=any> {

--- a/src/feedbacks/loading/lazy-img/PLazyImg.stories.mdx
+++ b/src/feedbacks/loading/lazy-img/PLazyImg.stories.mdx
@@ -4,159 +4,29 @@ import PButton from '@/inputs/buttons/button/PButton';
 import PLottie from '@/foundation/lottie/PLottie';
 import { reactive, toRefs } from '@vue/composition-api';
 import faker from 'faker';
+import {getLazyImgArgTypes} from '@/feedbacks/loading/lazy-img/story-helper';
 
 <Meta title='Feedbacks/Loading/Lazy Image' parameters={{
     design: {
         type: 'figma',
         url: 'https://www.figma.com/file/wq4wSowBcADBuUrMEZLz6i/SpaceONE-Console-Design?node-id=6132%3A133538',
     }
-}} argTypes={{
-    height: {
-        name: 'height',
-        type: { name: 'string' },
-        description: `Height of image`,
-        defaultValue: '2rem',
-        table: {
-            type: {
-                summary: 'string'
-            },
-            defaultValue: {
-                summary: '"2rem"'
-            },
-            category: 'props'
-        },
-        control: {
-            type: 'text'
-        }
-    },
-    width: {
-        name: 'width',
-        type: { name: 'string' },
-        description: `Height of image`,
-        defaultValue: '2rem',
-        table: {
-            type: {
-                summary: 'string'
-            },
-            defaultValue: {
-                summary: '"2rem"'
-            },
-            category: 'props'
-        },
-        control: {
-            type: 'text'
-        }
-    },
-    src: {
-        name: 'src',
-        type: { name: 'string' },
-        description: `Source of image`,
-        defaultValue: '',
-        table: {
-            type: {
-                summary: 'string'
-            },
-            defaultValue: {
-                summary: 'undefined'
-            },
-            category: 'props'
-        },
-        control: {
-            type: 'text'
-        }
-    },
-    errorIcon: {
-        name: 'errorIcon',
-        type: { name: 'string' },
-        description: `Alternative icon name when failed to load image. Refer to Icon component.`,
-        defaultValue: 'ic_collector_tags',
-        table: {
-            type: {
-                summary: 'string'
-            },
-            defaultValue: {
-                summary: '"ic_collector_tags"'
-            },
-            category: 'props'
-        },
-        control: {
-            type: 'text'
-        }
-    },
-    loading: {
-        name: 'loading',
-        type: { name: 'boolean' },
-        description: `Manual loading controller. If it's not given, it works automatically.`,
-        defaultValue: undefined,
-        table: {
-            type: {
-                summary: 'boolean'
-            },
-            defaultValue: {
-                summary: 'undefined'
-            },
-            category: 'props'
-        },
-        control: {
-            type: 'boolean'
-        }
-    },
-    alt: {
-        name: 'alt',
-        type: { name: 'string' },
-        description: `alt attribute of image tag.`,
-        defaultValue: undefined,
-        table: {
-            type: {
-                summary: 'string'
-            },
-            defaultValue: {
-                summary: 'undefined'
-            },
-            category: 'props'
-        },
-        control: {
-            type: 'text'
-        }
-    },
-    preloaderSlot: {
-        name: 'preloader',
-        description: 'Slot for image loader',
-        defaultValue: null,
-        table: {
-            type: {
-                summary: null
-            },
-            defaultValue: {
-                summary: null
-            },
-            category: 'slots'
-        },
-        control: null
-    },
-    errorSlot: {
-        name: 'error',
-        description: 'Slot for error icon',
-        defaultValue: null,
-        table: {
-            type: {
-                summary: null
-            },
-            defaultValue: {
-                summary: null
-            },
-            category: 'slots'
-        },
-        control: null
-    }
-}}/>
+}} argTypes={getLazyImgArgTypes()}/>
 
 
 export const Template = (args, { argTypes }) => ({
     props: Object.keys(argTypes),
     components: { PLazyImg },
     template: `
-          <p-lazy-img v-bind="$props"></p-lazy-img>
+        <p-lazy-img
+            :height="height"
+            :width="width"
+            :src="src"
+            :errorIcon="errorIcon"
+            :errorIconColor="errorIconColor"
+            :loading="loading"
+            :alt="alt"
+        ></p-lazy-img>
     `,
     setup() {
         return {}
@@ -193,6 +63,10 @@ export const Template = (args, { argTypes }) => ({
         <div class="flex items-center mb-4">
             <h2 class=" mr-4">Default: </h2>
             <p-lazy-img src="" />
+        </div>
+        <div class="flex items-center mb-4">
+            <h2 class=" mr-4">Custom Error Icon Color: </h2>
+            <p-lazy-img src="" error-icon-color="red white" />
         </div>
         <div class="flex items-center mb-4">
             <h2 class=" mr-4">Custom Error Icon: </h2>

--- a/src/feedbacks/loading/lazy-img/PLazyImg.vue
+++ b/src/feedbacks/loading/lazy-img/PLazyImg.vue
@@ -14,7 +14,7 @@
         <span v-show="!loading && status === LOAD_STATUS.errored" key="error-img" class="img-container error">
             <slot name="error" v-bind="{...$props, ...$data}">
                 <p-i :name="errorIcon || 'ic_collector_tags'" :style="{height, width}"
-                     :height="height"
+                     :height="height" :color="errorIconColor"
                      :width="width"
                 />
             </slot>
@@ -40,6 +40,7 @@ interface Props {
     width?: string;
     src: string;
     errorIcon?: string;
+    errorIconColor?: string;
     loading?: boolean;
     alt?: string;
 }
@@ -72,6 +73,10 @@ export default defineComponent<Props>({
         errorIcon: {
             type: String,
             default: 'ic_collector_tags',
+        },
+        errorIconColor: {
+            type: String,
+            default: '',
         },
         loading: {
             type: Boolean,

--- a/src/feedbacks/loading/lazy-img/story-helper.ts
+++ b/src/feedbacks/loading/lazy-img/story-helper.ts
@@ -1,0 +1,161 @@
+import { ArgTypes } from '@storybook/addons';
+
+export const getLazyImgArgTypes = (): ArgTypes => ({
+    height: {
+        name: 'height',
+        type: { name: 'string' },
+        description: 'Height of image',
+        defaultValue: '2rem',
+        table: {
+            type: {
+                summary: 'string',
+            },
+            defaultValue: {
+                summary: '"2rem"',
+            },
+            category: 'props',
+        },
+        control: {
+            type: 'text',
+        },
+    },
+    width: {
+        name: 'width',
+        type: { name: 'string' },
+        description: 'Height of image',
+        defaultValue: '2rem',
+        table: {
+            type: {
+                summary: 'string',
+            },
+            defaultValue: {
+                summary: '"2rem"',
+            },
+            category: 'props',
+        },
+        control: {
+            type: 'text',
+        },
+    },
+    src: {
+        name: 'src',
+        type: { name: 'string' },
+        description: 'Source of image',
+        defaultValue: '',
+        table: {
+            type: {
+                summary: 'string',
+            },
+            defaultValue: {
+                summary: 'undefined',
+            },
+            category: 'props',
+        },
+        control: {
+            type: 'text',
+        },
+    },
+    errorIcon: {
+        name: 'errorIcon',
+        type: { name: 'string' },
+        description: 'Alternative icon name when failed to load image. Refer to Icon component.',
+        defaultValue: 'ic_collector_tags',
+        table: {
+            type: {
+                summary: 'string',
+            },
+            defaultValue: {
+                summary: '"ic_collector_tags"',
+            },
+            category: 'props',
+        },
+        control: {
+            type: 'text',
+        },
+    },
+    errorIconColor: {
+        name: 'errorIconColor',
+        type: { name: 'string' },
+        description: 'Alternative icon\'s color.',
+        defaultValue: '',
+        table: {
+            type: {
+                summary: 'string',
+            },
+            defaultValue: {
+                summary: '""',
+            },
+            category: 'props',
+        },
+        control: {
+            type: 'text',
+        },
+    },
+    loading: {
+        name: 'loading',
+        type: { name: 'boolean' },
+        description: 'Manual loading controller. If it\'s not given, it works automatically.',
+        defaultValue: undefined,
+        table: {
+            type: {
+                summary: 'boolean',
+            },
+            defaultValue: {
+                summary: 'undefined',
+            },
+            category: 'props',
+        },
+        control: {
+            type: 'boolean',
+        },
+    },
+    alt: {
+        name: 'alt',
+        type: { name: 'string' },
+        description: 'alt attribute of image tag.',
+        defaultValue: undefined,
+        table: {
+            type: {
+                summary: 'string',
+            },
+            defaultValue: {
+                summary: 'undefined',
+            },
+            category: 'props',
+        },
+        control: {
+            type: 'text',
+        },
+    },
+    /* slots */
+    preloaderSlot: {
+        name: 'preloader',
+        description: 'Slot for image loader',
+        defaultValue: null,
+        table: {
+            type: {
+                summary: null,
+            },
+            defaultValue: {
+                summary: null,
+            },
+            category: 'slots',
+        },
+        control: null,
+    },
+    errorSlot: {
+        name: 'error',
+        description: 'Slot for error icon',
+        defaultValue: null,
+        table: {
+            type: {
+                summary: null,
+            },
+            defaultValue: {
+                summary: null,
+            },
+            category: 'slots',
+        },
+        control: null,
+    },
+});

--- a/src/inputs/select-card/PSelectCard.stories.mdx
+++ b/src/inputs/select-card/PSelectCard.stories.mdx
@@ -169,8 +169,8 @@ export const Template = (args, { argTypes }) => ({
         <p-select-card v-for="value in values" :key="value"
             :value="value"
             v-model="selected"
-            :label="icons[value]"
-            :image-url="icons[value]"
+            :label="'label-' + value"
+            :icon="true"
             style="min-width: 10rem; max-width: 10rem; min-height: 10rem; max-height: 10rem; margin: 1rem;"
         />
     </div>
@@ -179,7 +179,6 @@ export const Template = (args, { argTypes }) => ({
                 const state = reactive({
                     selected: undefined,
                     values: range(8),
-                    icons: getAllAvailableIcons()
                 })
                 return {
                     ...toRefs(state),

--- a/src/inputs/select-card/PSelectCard.stories.mdx
+++ b/src/inputs/select-card/PSelectCard.stories.mdx
@@ -6,7 +6,7 @@ import {
 import { range } from 'lodash'
 import { makeOptionalProxy } from '@/util/composition-helpers';
 import {getAllAvailableIcons } from '@/foundation/icons/helper';
-import { argTypes } from '@/inputs/select-card/story-helper';
+import { getSelectCardArgTypes } from '@/inputs/select-card/story-helper';
 import PSelectCard from './PSelectCard.vue';
 import { peacock } from '@/styles/colors'
 
@@ -15,7 +15,7 @@ import { peacock } from '@/styles/colors'
         type: 'figma',
         url: 'https://www.figma.com/file/wq4wSowBcADBuUrMEZLz6i/SpaceONE-Console-Design?node-id=13512%3A300523'
     }
-}} argTypes={argTypes}/>
+}} argTypes={getSelectCardArgTypes()}/>
 
 
 export const Template = (args, { argTypes }) => ({
@@ -32,6 +32,7 @@ export const Template = (args, { argTypes }) => ({
             :label="label"
             :image-url="imageUrl"
             :icon="icon"
+            :icon-color="iconColor"
             @change="onChange"
             style="min-width: 12rem; max-width: 100%; height: 100%; max-height: 12rem;"
         >
@@ -155,6 +156,42 @@ export const Template = (args, { argTypes }) => ({
 
 <br/>
 <br/>
+
+
+## With Default Icon
+
+<Canvas>
+    <Story name="With Default Icon">
+        {{
+            components: { PSelectCard },
+            template: `
+    <div class="h-full w-full overflow p-8">
+        <p-select-card v-for="value in values" :key="value"
+            :value="value"
+            v-model="selected"
+            :label="icons[value]"
+            :image-url="icons[value]"
+            style="min-width: 10rem; max-width: 10rem; min-height: 10rem; max-height: 10rem; margin: 1rem;"
+        />
+    </div>
+    `,
+            setup() {
+                const state = reactive({
+                    selected: undefined,
+                    values: range(8),
+                    icons: getAllAvailableIcons()
+                })
+                return {
+                    ...toRefs(state),
+                };
+            }
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
 
 ## Multi Select
 

--- a/src/inputs/select-card/PSelectCard.vue
+++ b/src/inputs/select-card/PSelectCard.vue
@@ -9,6 +9,7 @@
         <div class="contents">
             <slot v-bind="{isSelected}">
                 <p-lazy-img v-if="imageUrl || icon" :src="imageUrl" :error-icon="icon || 'smile-face'"
+                            :error-icon-color="icon ? iconColor : 'inherit'"
                             :width="block ? '1rem' : '3rem'" :height="block ? '1rem' : '3rem'"
                 />
                 <span v-if="label" class="label">{{ label }}</span>
@@ -31,8 +32,11 @@ import {
 
 
 interface Props extends SelectProps {
-    multiSelectable: boolean;
-    block: boolean;
+    block?: boolean;
+    imageUrl?: string;
+    icon?: string;
+    iconColor?: string;
+    label?: string;
 }
 
 export default defineComponent<Props>({
@@ -79,6 +83,10 @@ export default defineComponent<Props>({
         icon: {
             type: String,
             default: undefined,
+        },
+        iconColor: {
+            type: String,
+            default: '',
         },
         label: {
             type: String,
@@ -151,14 +159,10 @@ export default defineComponent<Props>({
         height: 100%;
 
         .p-lazy-img {
+            @apply text-gray-200;
             margin-right: 0;
             margin-bottom: 1rem;
             flex-shrink: 0;
-            .error {
-                path {
-                    fill: theme('colors.gray.300');
-                }
-            }
         }
 
         .label {

--- a/src/inputs/select-card/PSelectCard.vue
+++ b/src/inputs/select-card/PSelectCard.vue
@@ -8,8 +8,8 @@
         />
         <div class="contents">
             <slot v-bind="{isSelected}">
-                <p-lazy-img v-if="imageUrl || icon" :src="imageUrl" :error-icon="icon || 'smile-face'"
-                            :error-icon-color="icon ? iconColor : 'inherit'"
+                <p-lazy-img v-if="imageUrl || icon" :src="imageUrl" :error-icon="errorIcon"
+                            :error-icon-color="typeof icon === 'boolean' && icon ? 'inherit' : iconColor"
                             :width="block ? '1rem' : '3rem'" :height="block ? '1rem' : '3rem'"
                 />
                 <span v-if="label" class="label">{{ label }}</span>
@@ -21,7 +21,7 @@
 <script lang="ts">
 import {
     computed,
-    defineComponent, toRefs,
+    defineComponent, reactive, toRefs,
 } from '@vue/composition-api';
 
 import PI from '@/foundation/icons/PI.vue';
@@ -34,7 +34,7 @@ import {
 interface Props extends SelectProps {
     block?: boolean;
     imageUrl?: string;
-    icon?: string;
+    icon?: string|boolean;
     iconColor?: string;
     label?: string;
 }
@@ -81,7 +81,7 @@ export default defineComponent<Props>({
             default: undefined,
         },
         icon: {
-            type: String,
+            type: [String, Boolean],
             default: undefined,
         },
         iconColor: {
@@ -94,7 +94,15 @@ export default defineComponent<Props>({
         },
     },
     setup(props: Props, context) {
-        const { state, onClick } = useSelect(props, context);
+        const { state: selectState, onClick } = useSelect(props, context);
+
+        const state = reactive({
+            errorIcon: computed(() => {
+                if (typeof props.icon === 'string') return props.icon;
+                if (props.icon) return 'smile-face';
+                return '';
+            }),
+        });
 
         const iconName = computed(() => {
             if (props.multiSelectable) {
@@ -108,6 +116,7 @@ export default defineComponent<Props>({
         });
 
         return {
+            ...toRefs(selectState),
             ...toRefs(state),
             onClick,
             iconName,

--- a/src/inputs/select-card/story-helper.ts
+++ b/src/inputs/select-card/story-helper.ts
@@ -1,7 +1,7 @@
 import { argTypes as selectArgTypes } from '@/hooks/select/story-helper';
 import { ArgTypes } from '@storybook/addons';
 
-const getArgTypes = () => {
+export const getSelectCardArgTypes = () => {
     const argTypes: ArgTypes = {
         ...selectArgTypes,
         block: {
@@ -78,6 +78,24 @@ const getArgTypes = () => {
                 type: 'text',
             },
         },
+        iconColor: {
+            name: 'iconColor',
+            type: { name: 'string' },
+            description: 'Card icon\'s color.',
+            defaultValue: '',
+            table: {
+                type: {
+                    summary: 'string',
+                },
+                category: 'props',
+                defaultValue: {
+                    summary: '""',
+                },
+            },
+            control: {
+                type: 'text',
+            },
+        },
         defaultSlot: {
             name: 'default',
             description: 'Slot for card contents.',
@@ -109,4 +127,3 @@ const getArgTypes = () => {
     };
     return argTypes;
 };
-export const argTypes = getArgTypes();

--- a/src/inputs/select-card/story-helper.ts
+++ b/src/inputs/select-card/story-helper.ts
@@ -60,14 +60,15 @@ export const getSelectCardArgTypes = () => {
         },
         icon: {
             name: 'icon',
-            type: { name: 'string' },
+            type: { name: 'string, boolean' },
             description: `Card icon.
         It has a lower priority than \`imageUrl\` props.
-        So it is rendered only when there is no value in \`imageUrl\` props or when the image load fails.`,
+        So it is rendered only when there is no value in \`imageUrl\` props or when the image load fails.
+        If it is \`true\`, default icon will be rendered.`,
             defaultValue: 'ic_service_compute-engine',
             table: {
                 type: {
-                    summary: 'string',
+                    summary: 'string, boolean',
                 },
                 category: 'props',
                 defaultValue: {


### PR DESCRIPTION
### 작업 개요
- lazy img 컴포넌트에 error icon color props 추가
- select card 컴포넌트에 icon color props 추가
- select card 에 무조건 icon 컬러가 고정되는 버그 수정
- select card icon props 에 boolean 타입 추가(기본 아이콘 사용하는 경우)


### 작업 분류
- [x] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
