### PR TITLE
fix: change copy button from inline flex to inline block

### DIFF
--- a/src/inputs/buttons/copy-button/PCopyButton.vue
+++ b/src/inputs/buttons/copy-button/PCopyButton.vue
@@ -162,9 +162,9 @@ export default defineComponent<Props>({
 
 .p-copy-button {
     @apply text-gray-900;
-    display: inline-flex;
+    display: inline-block;
     font-size: 0.875rem;
-    align-items: center;
+    vertical-align: middle;
 
     .copy-icon {
         @apply text-gray-500;


### PR DESCRIPTION
### 작업 개요
- copy button style inline flex 에서  inline block 으로 변경
