### PR TITLE
fix: add commaFormatter to total count

### DIFF
--- a/src/data-display/titles/page-title/PPageTitle.vue
+++ b/src/data-display/titles/page-title/PPageTitle.vue
@@ -18,7 +18,7 @@
                     &nbsp;({{ $t('COMPONENT.PAGE_TITLE.SELECTED_OF',{selectedCount,totalCount}) }})
                 </span>
                 <span v-else class="total-count">
-                    &nbsp;({{ totalCount }})
+                    &nbsp;({{ commaFormatter(totalCount) }})
                 </span>
             </template>
         </slot>
@@ -30,6 +30,7 @@
 
 <script lang="ts">
 import PIconButton from '@/inputs/buttons/icon-button/PIconButton.vue';
+import { commaFormatter } from '@/util/helpers';
 
 export default {
     name: 'PPageTitle',
@@ -61,8 +62,14 @@ export default {
             default: 0,
         },
     },
+    setup() {
+        return {
+            commaFormatter,
+        };
+    },
 };
 </script>
+import { commaFormatter } from '@/util/helpers';
 
 <style lang="postcss">
 .p-page-title {

--- a/src/data-display/titles/panel-top/PPanelTop.vue
+++ b/src/data-display/titles/panel-top/PPanelTop.vue
@@ -14,6 +14,8 @@
     </div>
 </template>
 <script lang="ts">
+import { commaFormatter } from '@/util/helpers';
+
 export default {
     name: 'PPanelTop',
     props: {
@@ -31,10 +33,6 @@ export default {
         },
     },
     setup() {
-        const commaFormatter = (num) => {
-            if (num) return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-            return num;
-        };
         return {
             commaFormatter,
         };

--- a/src/data-display/titles/panel-top/PPanelTop.vue
+++ b/src/data-display/titles/panel-top/PPanelTop.vue
@@ -6,7 +6,7 @@
             </slot>
         </span>
         <span v-if="useTotalCount" class="total-count">
-            &nbsp;({{ totalCount }})
+            &nbsp;({{ commaFormatter(totalCount) }})
         </span>
         <span class="extra">
             <slot name="extra" />
@@ -29,6 +29,15 @@ export default {
             type: String,
             default: '',
         },
+    },
+    setup() {
+        const commaFormatter = (num) => {
+            if (num) return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+            return num;
+        };
+        return {
+            commaFormatter,
+        };
     },
 };
 </script>

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -43,6 +43,11 @@ export const getColor = (col?: string|null) => {
     return col;
 };
 
+export const commaFormatter = (num?: number) => {
+    if (num) return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    return num;
+};
+
 export const getPageStart = (thisPage: number, pageSize: number) => ((thisPage - 1) * pageSize) + 1;
 
 export const getThisPage = (pageStart = 1, pageLimit = 15) => Math.floor(pageStart / pageLimit) || 1;


### PR DESCRIPTION
### 작업 개요
panel-top의 total-count에 표기법 (comma)추가 했습니다.

### 작업 분류
- [ ] 버그 수정
- [X] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
![image](https://user-images.githubusercontent.com/19162140/126099130-4a70fce3-1798-4d6c-889e-5e6942bbf102.png)

콘솔 페이지에서 commaFormatter로 추가 했더니 타입오류가 났습니다.
컴포넌트의 total-count props 타입은 Number 인데, 페이지에서 commaFormatter로 바꾸는 과정에서 String이 되는걸로 확인했어요~!

해당 스펙은 컴포넌트에 포함 되도 좋을것 같아서 디자인 시스템에 추가하는게 어떨가 싶습니다.