### PR TITLE
fix: add rollback cb function to drop event param in tree

### DIFF
--- a/src/data-display/tree/PTree.stories.mdx
+++ b/src/data-display/tree/PTree.stories.mdx
@@ -105,11 +105,11 @@ export const ExpertTemplate = (args, { argTypes }) => ({
             })),
             dragOptions: computed(() => ({
                 disabled: !state.editMode,
-                dragValidator(node, parent) {
+                dragValidator(node, dragNodeParent) {
                     return !!state.permissionInfo[node.data.id]
                 },
-                dropValidator(node, parent) {
-                    if (state.dragParentNode === parent) return true;
+                dropValidator(node, oldParent, parent) {
+                    if (oldParent === parent) return true;
                     return !!state.permissionInfo[parent?.data?.id]
                 }
             })),
@@ -122,7 +122,6 @@ export const ExpertTemplate = (args, { argTypes }) => ({
             editText: '',
             selectedItem: {},
             dragNode: null,
-            dragParentNode: null
         })
         const selectOptions = {
                 validator({data}) {
@@ -214,13 +213,12 @@ export const ExpertTemplate = (args, { argTypes }) => ({
             state.selectedItem = selected.length > 0 ? selected[0] : {};
             state.editText = selected.length ? selected[0].node.data.name : ''
         }
-        const onStartDrag = (node, parent) => {
-            console.debug('start drag', node, parent)
+        const onStartDrag = (node, dragNodeParent) => {
+            console.debug('start drag', node, dragNodeParent)
             state.dragNode = node
-            state.dragParentNode = parent
         }
-        const onDrop = (node, parent, rollback) => {
-            console.debug('drop', node, parent, rollback)
+        const onDrop = (node, oldParent, parent, rollback) => {
+            console.debug('drop', node, oldParent, parent, rollback)
             if (Math.random() > 0.5) {
                 alert('Drop Failed! Rollback.');
                 rollback();
@@ -229,7 +227,6 @@ export const ExpertTemplate = (args, { argTypes }) => ({
         const onEndDrag = (node, parent) => {
             console.debug('end drag', node, parent)
             state.dragNode = null
-            state.dragParentNode = null
         }
         const onFinishEdit = (node, editText) => {
             console.debug('finish edit', node, editText)
@@ -411,15 +408,15 @@ Options for node drag & drop.
 |dragValidator|Whether to enable or disable dragging each node.|
 |dropValidator|Whether to enable or disable dropping each node.|
 |startValidator|Whether to allow dragging of each node and emit `start-drag` event or not.|
-|endValidator|Whether to allow dropping of each node and emit `update--drag` event or not.|
+|endValidator|Whether to allow dropping of each node and emit `drop` event or not.|
 
 ```typescript
 interface DragOptions {
     disabled?: boolean;
-    dragValidator?: (node?: TreeNode, parent?: null|TreeNode) => boolean;
-    dropValidator?: (node?: TreeNode, parent?: null|TreeNode) => boolean;
-    startValidator?: (node?: TreeNode, parent?: null|TreeNode) => boolean;
-    endValidator?: (node?: TreeNode, parent?: null|TreeNode) => boolean;
+    startValidator?: (node?: TreeNode, dragNodeParent?: null|TreeNode) => boolean;
+    dragValidator?: (node?: TreeNode, dragNodeParent?: null|TreeNode) => boolean;
+    dropValidator?: (node?: TreeNode, oldParent?: null|TreeNode, parent?: null|TreeNode) => boolean;
+    endValidator?: (node?: TreeNode, oldParent?: null|TreeNode, parent?: null|TreeNode) => boolean;
 }
 ```
 
@@ -463,8 +460,8 @@ interface DataFetcher<T=any> {
 |click-node| Emitted when click nodes. Pass node and path. |
 |change-select| Emitted when selection items changed. Pass selected items. `TreeItem<T>[]` |
 |start-drag| Emitted when dragging start. Pass dragging node and parent node. |
-|end-drag| Emitted when finished dragging. Pass dragging node and parent of target node. |
-|drop| Emitted when finished dragging and finally dropped. Pass dropped node, parent, and rollback function. |
+|end-drag| Emitted when finished dragging. Pass dragging node, old parent node, and the parent of target node. |
+|drop| Emitted when finished dragging and finally dropped. Pass dropped node, old parent node, and updated parent node, and rollback function. |
 |finish-edit| Emitted when finished inline editing. Pass the node and the input text. |
 
 ```typescript

--- a/src/data-display/tree/PTree.stories.mdx
+++ b/src/data-display/tree/PTree.stories.mdx
@@ -48,7 +48,7 @@ export const ExpertTemplate = (args, { argTypes }) => ({
                     @init="onInit"
                     @change-select="onChangeSelect"
                     @start-drag="onStartDrag"
-                    @update-drag="onUpdateDrag"
+                    @drop="onDrop"
                     @end-drag="onEndDrag"
                     @finish-edit="onFinishEdit"
             >
@@ -219,8 +219,12 @@ export const ExpertTemplate = (args, { argTypes }) => ({
             state.dragNode = node
             state.dragParentNode = parent
         }
-        const onUpdateDrag = (node, parent, rollback) => {
-            console.debug('update drag', node, parent, rollback)
+        const onDrop = (node, parent, rollback) => {
+            console.debug('drop', node, parent, rollback)
+            if (Math.random() > 0.5) {
+                alert('Drop Failed! Rollback.');
+                rollback();
+            }
         }
         const onEndDrag = (node, parent) => {
             console.debug('end drag', node, parent)
@@ -258,7 +262,7 @@ export const ExpertTemplate = (args, { argTypes }) => ({
             updateData,
             onChangeSelect,
             onStartDrag,
-            onUpdateDrag,
+            onDrop,
             onEndDrag,
             onFinishEdit,
             changeSelectState
@@ -460,7 +464,7 @@ interface DataFetcher<T=any> {
 |change-select| Emitted when selection items changed. Pass selected items. `TreeItem<T>[]` |
 |start-drag| Emitted when dragging start. Pass dragging node and parent node. |
 |end-drag| Emitted when finished dragging. Pass dragging node and parent of target node. |
-|update-drag| Emitted when finished dragging and all validations are passed. Pass dragging node and parent of target node. |
+|drop| Emitted when finished dragging and finally dropped. Pass dropped node, parent, and rollback function. |
 |finish-edit| Emitted when finished inline editing. Pass the node and the input text. |
 
 ```typescript

--- a/src/data-display/tree/PTree.vue
+++ b/src/data-display/tree/PTree.vue
@@ -88,14 +88,14 @@ import {
     GetClassNames, DataFetcher,
 } from '@/data-display/tree/type';
 import { getDefaultNode } from '@/data-display/tree/helper';
-import { CloneTreeDataOptions, Store, WalkTreeDataCallback } from '@/data-display/tree/he-tree-vue/types';
+import {
+    CloneTreeDataOptions, HeTree, Store, WalkTreeDataCallback,
+} from '@/data-display/tree/he-tree-vue/types';
 import OriginTree from './he-tree-vue/components/Tree.vue';
-import Draggable from './he-tree-vue/plugins/draggable/Draggable.vue';
-import Fold from './he-tree-vue/plugins/fold';
+import DraggablePlugin from './he-tree-vue/plugins/draggable/Draggable.vue';
+import FoldPlugin from './he-tree-vue/plugins/fold';
 import { walkTreeData, cloneTreeData } from './he-tree-vue/utils';
 
-// interface HeTree extends OriginTree, Fold, Draggable {}
-type HeTree = any;
 
 interface Props {
     toggleOptions: ToggleOptions;
@@ -109,7 +109,7 @@ interface Props {
     getClassNames: GetClassNames;
 }
 
-const MixedTree = (OriginTree as any).mixPlugins([Fold, Draggable]);
+const MixedTree = (OriginTree as any).mixPlugins([FoldPlugin, DraggablePlugin]);
 
 export default defineComponent<Props>({
     name: 'PTree',
@@ -282,19 +282,20 @@ export default defineComponent<Props>({
         const onDragEnd = (tree: HeTree, e: Store) => {
             state.dragTargetParentPath = null;
             const parent = e.targetPath ? tree.getNodeParentByPath(e.targetPath) as TreeNode : null;
+            const oldParent = e.startPath ? tree.getNodeParentByPath(e.startPath) as TreeNode : null;
 
             const validator = props.dragOptions.endValidator;
 
-            if (validator && !validator(e.dragNode as TreeNode, parent)) {
-                emit('end-drag', e.dragNode, parent);
+            if (validator && !validator(e.dragNode as TreeNode, oldParent, parent)) {
+                emit('end-drag', e.dragNode, oldParent, parent);
                 return false;
             }
 
-            emit('end-drag', e.dragNode, parent);
+            emit('end-drag', e.dragNode, oldParent, parent);
             return true;
         };
 
-        const handleDrop = (tree, e: Store, targetPath, _rollback) => {
+        const handleDrop = (e: Store, targetPath, _rollback) => {
             const rollback = () => {
                 _rollback();
 
@@ -306,8 +307,9 @@ export default defineComponent<Props>({
             if (getSelectState(e.startPath ?? [])) {
                 setSelectItem(e.dragNode as TreeNode, targetPath);
             }
-
-            emit('drop', e.dragNode, tree.getNodeParentByPath(targetPath), rollback);
+            const oldParent = e.startPath ? e.startTree?.getNodeParentByPath(e.startPath) as TreeNode : null;
+            const parent = e.targetTree?.getNodeParentByPath(targetPath) as TreeNode;
+            emit('drop', e.dragNode, oldParent, parent, rollback);
         };
 
         const eachDraggable = (path: number[], tree: HeTree, e: Store) => {
@@ -326,9 +328,11 @@ export default defineComponent<Props>({
                 parent = tree.getNodeByPath(parentPath) as TreeNode;
             }
 
+            const oldParent = e.startPath ? tree.getNodeParentByPath(e.startPath) : null;
+
             state.dragTargetParentPath = parentPath;
 
-            if (dropValidator && !dropValidator(e.dragNode as TreeNode, parent)) return false;
+            if (dropValidator && !dropValidator(e.dragNode as TreeNode, oldParent as TreeNode, parent)) return false;
             return true;
         };
         const finishEdit = (node: TreeNode) => {

--- a/src/data-display/tree/PTree.vue
+++ b/src/data-display/tree/PTree.vue
@@ -290,15 +290,24 @@ export default defineComponent<Props>({
                 return false;
             }
 
-            emit('update-drag', e.dragNode, parent);
             emit('end-drag', e.dragNode, parent);
             return true;
         };
 
-        const handleDrop = (e, targetPath) => {
+        const handleDrop = (tree, e: Store, targetPath, _rollback) => {
+            const rollback = () => {
+                _rollback();
+
+                if (getSelectState(targetPath ?? [])) {
+                    setSelectItem(e.dragNode as TreeNode, e.startPath);
+                }
+            };
+
             if (getSelectState(e.startPath ?? [])) {
                 setSelectItem(e.dragNode as TreeNode, targetPath);
             }
+
+            emit('drop', e.dragNode, tree.getNodeParentByPath(targetPath), rollback);
         };
 
         const eachDraggable = (path: number[], tree: HeTree, e: Store) => {

--- a/src/data-display/tree/he-tree-vue/plugins/draggable/Draggable.vue
+++ b/src/data-display/tree/he-tree-vue/plugins/draggable/Draggable.vue
@@ -213,10 +213,36 @@ export default {
                     }
                     const targetIndex = hp.arrayLast(targetPath);
                     targetSiblings.splice(targetIndex, 0, dragNode);
+
+                    const rollback = () => {
+                        // remove inserted node from target position
+                        const targetParentPath = hp.arrayWithoutEnd(targetPath, 1);
+                        const targetParent = targetTree.getNodeByPath(targetParentPath);
+                        const targetSiblings = targetParentPath.length === 0 ? targetTree.treeData : targetParent.children;
+                        const targetIndex = hp.arrayLast(targetPath);
+                        targetSiblings.splice(targetIndex, 1);
+
+                        // add node to start position
+                        const startParentPath = hp.arrayWithoutEnd(startPath, 1);
+                        const startParent = startTree.getNodeByPath(startParentPath);
+                        // const startSiblings = startParentPath.length === 0 ? startTree.treeData : startParent.children;
+                        let startSiblings;
+                        if (startParentPath.length === 0) {
+                            startSiblings = startTree.treeData;
+                        } else {
+                            if (!startParent.children) {
+                                this.$set(startParent, 'children', []);
+                            }
+                            startSiblings = startParent.children;
+                        }
+                        const startIndex = hp.arrayLast(startPath);
+                        startSiblings.splice(startIndex, 0, dragNode);
+                    }
+
                     // emit event
                     startTree.$emit('input', startTree.treeData);
                     startTree.$emit('change', store);
-                    targetTree.$emit('drop', store, targetPath);
+                    targetTree.$emit('drop', targetTree, store, targetPath, rollback);
                     this.$root.$emit('he-tree-drop', store);
                     if (targetTree !== startTree) {
                         targetTree.$emit('input', targetTree.treeData);

--- a/src/data-display/tree/he-tree-vue/plugins/draggable/Draggable.vue
+++ b/src/data-display/tree/he-tree-vue/plugins/draggable/Draggable.vue
@@ -1,10 +1,10 @@
-<script lang="js">
-/* eslint-disable */
+<script lang="ts">
 import * as hp from 'helper-js';
+import { Draggable, Store } from '@/data-display/tree/he-tree-vue/types';
 import * as ut from '../../utils';
 import makeTreeDraggable from './draggable';
 
-const treesStore = {};
+const treesStore = {} as {store: Store};
 
 export default {
     props: {
@@ -27,30 +27,44 @@ export default {
         edgeScrollSpecifiedContainerY: {}, // HTMLElement || ((store) => HTMLElement)
         preventTextSelection: { type: Boolean, default: true },
     },
-    // components: {},
     data() {
         return {
             treesStore,
         };
     },
-    // created() {},
     mounted() {
+        // @ts-ignore
         // eslint-disable-next-line no-multi-assign
         const options = this._draggableOptions = {
+            // @ts-ignore
             indent: this.indent,
+            // @ts-ignore
             triggerClass: this.triggerClass,
+            // @ts-ignore
             triggerBySelf: this.triggerBySelf,
+            // @ts-ignore
             unfoldWhenDragover: this.unfoldWhenDragover,
+            // @ts-ignore
             unfoldWhenDragoverDelay: this.unfoldWhenDragoverDelay,
+            // @ts-ignore
             draggingNodePositionMode: this.draggingNodePositionMode,
+            // @ts-ignore
             cloneWhenDrag: this.cloneWhenDrag,
+            // @ts-ignore
             edgeScroll: this.edgeScroll,
+            // @ts-ignore
             edgeScrollTriggerMargin: this.edgeScrollTriggerMargin,
+            // @ts-ignore
             edgeScrollSpeed: this.edgeScrollSpeed,
+            // @ts-ignore
             edgeScrollTriggerMode: this.edgeScrollTriggerMode,
+            // @ts-ignore
             edgeScrollSpecifiedContainerX: this.edgeScrollSpecifiedContainerX,
+            // @ts-ignore
             edgeScrollSpecifiedContainerY: this.edgeScrollSpecifiedContainerY,
+            // @ts-ignore
             rtl: this.rtl,
+            // @ts-ignore
             preventTextSelection: this.preventTextSelection,
             treeClass: 'he-tree',
             rootClass: 'tree-root',
@@ -75,8 +89,10 @@ export default {
                 }
                 return true;
             },
+            // @ts-ignore
             unfoldTargetNodeByEl: (...args) => this._Draggable_unfoldTargetNodeByEl(...args),
             isNodeParentDroppable: (branchEl, treeEl) => {
+                // @ts-ignore
                 const tree = this.getTreeVmByTreeEl(treeEl);
                 const path = tree.getPathByBranchEl(branchEl);
                 const parentPath = hp.arrayWithoutEnd(path, 1);
@@ -84,22 +100,27 @@ export default {
                 return tree.isNodeDroppable(parent, parentPath);
             },
             isNodeDroppable: (branchEl, treeEl) => {
+                // @ts-ignore
                 const tree = this.getTreeVmByTreeEl(treeEl);
                 const path = tree.getPathByBranchEl(branchEl);
                 const node = tree.getNodeByPath(path);
                 return tree.isNodeDroppable(node, path);
             },
+            // eslint-disable-next-line consistent-return
             _findClosestDroppablePosition: (branchEl, treeEl) => {
+                // @ts-ignore
                 const tree = this.getTreeVmByTreeEl(treeEl);
                 const path = tree.getPathByBranchEl(branchEl);
                 const findPath = hp.arrayWithoutEnd(path, 1);
                 let cur = path;
+                // eslint-disable-next-line no-restricted-syntax,no-shadow
                 for (const { node, path } of tree.iteratePath(findPath, { reverse: true })) {
                     if (tree.isNodeDroppable(node, path)) {
                         return tree.getBranchElByPath(cur);
                     }
                     cur = path;
                 }
+                // @ts-ignore
                 if (tree.isNodeDroppable(this.rootNode, [])) {
                     return tree.getBranchElByPath(cur);
                 }
@@ -108,16 +129,22 @@ export default {
                 store.startTree.$emit('afterPlaceholderCreated', store);
                 store.startTree.$emit('after-placeholder-created', store);
             },
+            // @ts-ignore
             getPathByBranchEl: branchEl => this.getPathByBranchEl(branchEl),
+            // eslint-disable-next-line consistent-return
             beforeFirstMove: (store) => {
+                // @ts-ignore
                 this.treesStore.store = store;
+                // @ts-ignore
                 store.startTree = this.getTreeVmByTreeEl(store.startTreeEl);
                 const draggable = hp.resolveValueOrGettter(store.startTree.draggable, [store.startTree, store]);
                 if (!draggable) {
                     return false;
                 }
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 const { startTree, dragBranchEl, startPath } = store;
                 store.dragNode = startTree.getNodeByPath(startPath);
+                // @ts-ignore
                 if (this.cloneWhenDrag) {
                     store.dragNode = ut.cloneTreeData(store.dragNode);
                 }
@@ -129,13 +156,18 @@ export default {
                 }
                 store.startTree.$emit('before-first-move', store);
                 store.startTree.$emit('drag', store);
+                // @ts-ignore
                 this.$root.$emit('he-tree-drag', store);
             },
+            // eslint-disable-next-line consistent-return
             filterTargetTree: (targetTreeEl, store) => {
+                // @ts-ignore
                 const targetTree = this.getTreeVmByTreeEl(targetTreeEl);
                 const { startTree } = store;
                 if (startTree !== targetTree) {
+                    // @ts-ignore
                     if (this._internal_hook_filterTargetTree) {
+                        // @ts-ignore
                         if (this._internal_hook_filterTargetTree(targetTree, store) === false) {
                             return false;
                         }
@@ -148,6 +180,7 @@ export default {
                     return false;
                 }
                 store.targetTree = targetTree;
+                // @ts-ignore
                 if (!hp.resolveValueOrGettter(store.startTree === store.targetTree) && hp.resolveValueOrGettter(this._Draggable_unfoldTargetNode, [false, this.treeData]) !== this.rootNode.children) {
                     return false;
                 }
@@ -155,19 +188,23 @@ export default {
             afterMove: (store) => {
                 store.startTree.$emit('after-move', store);
             },
+            // eslint-disable-next-line consistent-return
             beforeDrop: (pathChanged, store) => {
                 const { targetTree } = store;
                 if (targetTree.hasHook('ondragend') && targetTree.executeHook('ondragend', [targetTree, store]) === false) {
                     return false;
                 }
+                // @ts-ignore
                 this.$root.$emit('he-tree-before-drop', store);
             },
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars,consistent-return
             afterDrop: (store, t) => {
                 if (store.pathChanged) {
                     const {
                         startTree, targetTree, startPath, dragNode,
                     } = store;
                     let { targetPath } = store;
+                    // @ts-ignore
                     if (this.cloneWhenDrag !== true) {
                         // remove from start position
                         const startParentPath = hp.arrayWithoutEnd(startPath, 1);
@@ -207,6 +244,7 @@ export default {
                         targetSiblings = targetTree.treeData;
                     } else {
                         if (!targetParent.children) {
+                            // @ts-ignore
                             this.$set(targetParent, 'children', []);
                         }
                         targetSiblings = targetParent.children;
@@ -216,9 +254,13 @@ export default {
 
                     const rollback = () => {
                         // remove inserted node from target position
+                        // eslint-disable-next-line no-shadow
                         const targetParentPath = hp.arrayWithoutEnd(targetPath, 1);
+                        // eslint-disable-next-line no-shadow
                         const targetParent = targetTree.getNodeByPath(targetParentPath);
+                        // eslint-disable-next-line no-shadow
                         const targetSiblings = targetParentPath.length === 0 ? targetTree.treeData : targetParent.children;
+                        // eslint-disable-next-line no-shadow
                         const targetIndex = hp.arrayLast(targetPath);
                         targetSiblings.splice(targetIndex, 1);
 
@@ -231,23 +273,26 @@ export default {
                             startSiblings = startTree.treeData;
                         } else {
                             if (!startParent.children) {
+                                // @ts-ignore
                                 this.$set(startParent, 'children', []);
                             }
                             startSiblings = startParent.children;
                         }
                         const startIndex = hp.arrayLast(startPath);
                         startSiblings.splice(startIndex, 0, dragNode);
-                    }
+                    };
 
                     // emit event
                     startTree.$emit('input', startTree.treeData);
                     startTree.$emit('change', store);
-                    targetTree.$emit('drop', targetTree, store, targetPath, rollback);
+                    targetTree.$emit('drop', store, targetPath, rollback);
+                    // @ts-ignore
                     this.$root.$emit('he-tree-drop', store);
                     if (targetTree !== startTree) {
                         targetTree.$emit('input', targetTree.treeData);
                         targetTree.$emit('change', store);
                     }
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
                     return new Promise((resolve, reject) => {
                         targetTree.$nextTick(() => {
                             resolve();
@@ -256,6 +301,8 @@ export default {
                 }
             },
         };
+        // @ts-ignore
+        // eslint-disable-next-line @typescript-eslint/camelcase,no-multi-assign
         const _makeTreeDraggable_obj = this._makeTreeDraggable_obj = makeTreeDraggable(this.$el, options);
         // watch props and update options
         ['indent',
@@ -269,6 +316,7 @@ export default {
             'rtl',
             'preventTextSelection',
         ].forEach((name) => {
+            // @ts-ignore
             this.$watch(name, (value) => {
                 _makeTreeDraggable_obj.options[name] = value;
                 _makeTreeDraggable_obj.optionsUpdated();
@@ -282,7 +330,9 @@ export default {
             const { targetTree } = store;
             const path = targetTree.getPathByBranchEl(branchEl);
             const node = targetTree.getNodeByPath(path);
+            // eslint-disable-next-line no-unused-expressions
             targetTree.unfold && targetTree.unfold(node, path);
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             return new Promise((resolve, reject) => {
                 targetTree.$nextTick(() => {
                     resolve();
@@ -290,14 +340,21 @@ export default {
             });
         },
         isNodeDraggable(node, path) {
+            // @ts-ignore
             const { store } = this.treesStore;
+            // @ts-ignore
             const allNodes = this.getAllNodesByPath(path);
+            // @ts-ignore
             allNodes.unshift(this.rootNode);
+            // eslint-disable-next-line no-restricted-syntax,no-shadow
             for (const { value: node, index } of hp.iterateAll(allNodes, { reverse: true })) {
-                const currentPath = path.slice(0, index + 1);
+                const currentPath = path.slice(0, (index ?? 0) + 1);
+                // @ts-ignore
                 const draggableOpt = node.$draggable !== undefined ? node.$draggable : this.eachDraggable;
+                // @ts-ignore
                 const draggable = hp.resolveValueOrGettter(draggableOpt, [currentPath, this, store]);
                 if (draggable === undefined) {
+                    // eslint-disable-next-line no-continue
                     continue;
                 } else {
                     return draggable;
@@ -306,16 +363,23 @@ export default {
             return true;
         },
         isNodeDroppable(node, path) {
+            // @ts-ignore
             const { store } = this.treesStore;
+            // @ts-ignore
             const allNodes = this.getAllNodesByPath(path);
+            // @ts-ignore
             allNodes.unshift(this.rootNode);
             let droppableFinal; let
                 resolved;
+            // eslint-disable-next-line no-shadow,no-restricted-syntax
             for (const { value: node, index } of hp.iterateAll(allNodes, { reverse: true })) {
-                const currentPath = path.slice(0, index + 1);
+                const currentPath = path.slice(0, (index ?? 0) + 1);
+                // @ts-ignore
                 const droppableOpt = node.$droppable !== undefined ? node.$droppable : this.eachDroppable;
+                // @ts-ignore
                 const droppable = hp.resolveValueOrGettter(droppableOpt, [currentPath, this, store]);
                 if (droppable === undefined) {
+                    // eslint-disable-next-line no-continue
                     continue;
                 } else {
                     droppableFinal = droppable;
@@ -326,7 +390,9 @@ export default {
             if (!resolved) {
                 droppableFinal = true;
             }
+            // @ts-ignore
             if (this._internal_hook_isNodeDroppable) {
+                // @ts-ignore
                 return this._internal_hook_isNodeDroppable({
                     droppableFinal, node, path, store,
                 });
@@ -335,7 +401,10 @@ export default {
         },
         // override
         getPathByBranchEl(branchEl) {
+            // @ts-ignore
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const store = this.treesStore.store;
+            // eslint-disable-next-line consistent-return
             const getAttrPath = (el) => {
                 const pathStr = el.getAttribute('data-tree-node-path');
                 if (pathStr) {
@@ -348,6 +417,7 @@ export default {
             }
             // placeholder path
             let parentPath;
+            // eslint-disable-next-line consistent-return
             hp.findParent(branchEl, (el) => {
                 if (hp.hasClass(el, 'tree-root')) {
                     parentPath = [];
@@ -357,8 +427,10 @@ export default {
                     parentPath = getAttrPath(el);
                     return true;
                 }
+                return false;
             });
             let index = 0;
+            // eslint-disable-next-line no-restricted-syntax,@typescript-eslint/no-unused-vars
             for (const { value: el, index: index2 } of hp.iterateAll(branchEl.parentElement.children)) {
                 if (hp.hasClass(el, 'tree-branch') || hp.hasClass(el, 'tree-placeholder')) {
                     if (el === branchEl) {
@@ -370,6 +442,6 @@ export default {
             return [...parentPath, index];
         },
     },
-};
+} as unknown as Draggable;
 
 </script>

--- a/src/data-display/tree/he-tree-vue/plugins/fold.ts
+++ b/src/data-display/tree/he-tree-vue/plugins/fold.ts
@@ -1,14 +1,15 @@
 import Vue from 'vue';
+import {
+    Fold, Node, Path, UnfoldOptions,
+} from '@/data-display/tree/he-tree-vue/types';
 import { walkTreeData } from '../utils';
 
 export function foldAll(treeData) {
-    // @ts-ignore
     walkTreeData(treeData, (childNode) => {
         Vue.set(childNode, '$folded', true);
     });
 }
 export function unfoldAll(treeData) {
-    // @ts-ignore
     walkTreeData(treeData, (childNode) => {
         Vue.set(childNode, '$folded', false);
     });
@@ -29,7 +30,7 @@ export default {
                 this.$emit('nodeFoldedChanged', node);
             }
         },
-        unfold(node, path, opt: any = {}) {
+        unfold(node, path, opt: UnfoldOptions = {}) {
             // eslint-disable-next-line no-param-reassign
             opt = {
                 foldOthers: false,
@@ -47,7 +48,7 @@ export default {
                 this.$emit('node-folded-changed', node);
             }
         },
-        toggleFold(node, path, opt) {
+        toggleFold(node: Node, path: Path, opt: UnfoldOptions) {
             if (node.$folded) {
                 this.unfold(node, path, opt);
             } else {
@@ -75,4 +76,4 @@ export default {
             this.foldAll();
         }
     },
-};
+} as unknown as Fold;

--- a/src/data-display/tree/he-tree-vue/utils.ts
+++ b/src/data-display/tree/he-tree-vue/utils.ts
@@ -1,6 +1,6 @@
 import { TreeData } from 'helper-js';
 
-export function cloneTreeData(treeData, opt) {
+export function cloneTreeData(treeData, opt?) {
     return (new TreeData(treeData)).clone(opt);
 }
 

--- a/src/data-display/tree/type.ts
+++ b/src/data-display/tree/type.ts
@@ -37,10 +37,10 @@ export interface EditOptions<T=any> {
 
 export interface DragOptions {
     disabled?: boolean;
-    dragValidator?: (node?: TreeNode, parent?: null|TreeNode) => boolean;
-    dropValidator?: (node?: TreeNode, parent?: null|TreeNode) => boolean;
-    startValidator?: (node?: TreeNode, parent?: null|TreeNode) => boolean;
-    endValidator?: (node?: TreeNode, parent?: null|TreeNode) => boolean;
+    startValidator?: (node?: TreeNode, dragNodeParent?: null|TreeNode) => boolean;
+    dragValidator?: (node?: TreeNode, dragNodeParent?: null|TreeNode) => boolean;
+    dropValidator?: (node?: TreeNode, oldParent?: null|TreeNode, parent?: null|TreeNode) => boolean;
+    endValidator?: (node?: TreeNode, oldParent?: null|TreeNode, parent?: null|TreeNode) => boolean;
 }
 
 export interface DataGetter<T=any> {


### PR DESCRIPTION
### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [x] 기능 개선
- [x] 리팩토링 및 구조 변경
- [ ] 기타

## 들어가기에 앞서, 빠른 리뷰를 위해서 마지막 커밋은 제외하고 봐주세요. 마지막 커밋은 타입스크립트 부분적용한 내용입니다.

### 작업 상세 내용

#### tree에 다음과 같은 작업 적용
1. update-drag 제거
2. drop 이벤트에 rollback 파라미터 추가
3. drop, end-drag 이벤트 파라미터, dragOptions.dropValidator, dragOptions.endValidator 함수 아규먼트에 oldParent 추가

#### tree, he-tree-vue 에 일부 타입스크립트 적용
라이브러리를 내장화하면서 타입스크립트가 미적용되어 버그 발생 가능성이 늘어나, 필요한 수준만큼만 적용

### 작업 결과
 

https://user-images.githubusercontent.com/26986739/150271151-9ad3d1c8-171b-464a-809e-4e05e5351a22.mov


