### PR TITLE
fix: don't use router-link if link is not given in ContextMenuItem

### DIFF
--- a/src/inputs/context-menu/context-menu-item/PContextMenuItem.vue
+++ b/src/inputs/context-menu/context-menu-item/PContextMenuItem.vue
@@ -1,42 +1,36 @@
 <template>
-    <router-link :key="name"
-                 custom
-                 :class="{ disabled, selected }"
-                 class="p-context-menu-item"
-                 :to="(to && !disabled) ? to : {}"
-                 :href="link ? link : undefined"
-                 :target="link ? '_blank' : undefined"
+    <component :is="isAnchor ? 'router-link' : 'span'"
+               class="p-context-menu-item"
+               :class="{selected, disabled}"
+               v-bind="{...routerLinkProps, ...$attrs}"
+               v-on="$listeners"
     >
-        <template #default>
-            <component :is="isAnchor ? 'a' : 'span'" v-bind="$attrs" v-on="$listeners">
-                <p-i v-if="selectIcon"
-                     class="select-marker"
-                     :name="selectIcon"
-                     width="1em" height="1em"
-                />
-                <span class="label-wrapper" :class="{ellipsis}">
-                    <p-text-highlighting v-if="highlightTerm && !$slots.default"
-                                         :text="label" :term="highlightTerm"
-                                         class="text" :class="{'is-anchor': isAnchor}"
-                                         style-type="secondary"
-                    >
-                        <template #default="textHighlightingSlotProps">
-                            <slot name="text-list" v-bind="{...textHighlightingSlotProps, ...$props}" />
-                        </template>
-                    </p-text-highlighting>
-                    <span v-else class="text" :class="{'is-anchor': isAnchor}">
-                        <slot name="default" v-bind="$props">
-                            {{ label }}
-                        </slot>
-                    </span>
-                    <p-i v-if="link" name="ic_external-link"
-                         class="external-link-icon"
-                         width="0.875rem" height="0.875rem"
-                    />
-                </span>
-            </component>
-        </template>
-    </router-link>
+        <p-i v-if="selectIcon"
+             class="select-marker"
+             :name="selectIcon"
+             width="1em" height="1em"
+        />
+        <span class="label-wrapper" :class="{ellipsis}">
+            <p-text-highlighting v-if="highlightTerm && !$slots.default"
+                                 :text="label" :term="highlightTerm"
+                                 class="text" :class="{'is-anchor': isAnchor}"
+                                 style-type="secondary"
+            >
+                <template #default="textHighlightingSlotProps">
+                    <slot name="text-list" v-bind="{...textHighlightingSlotProps, ...$props}" />
+                </template>
+            </p-text-highlighting>
+            <span v-else class="text" :class="{'is-anchor': isAnchor}">
+                <slot name="default" v-bind="$props">
+                    {{ label }}
+                </slot>
+            </span>
+            <p-i v-if="link" name="ic_external-link"
+                 class="external-link-icon"
+                 width="0.875rem" height="0.875rem"
+            />
+        </span>
+    </component>
 </template>
 
 <script lang="ts">
@@ -129,6 +123,16 @@ export default defineComponent<ContextMenuItemProps>({
                 return undefined;
             }),
             isAnchor: computed(() => !props.disabled && (props.link || props.to)),
+            routerLinkProps: computed(() => {
+                if (state.isAnchor) {
+                    return {
+                        to: props.to && !props.disabled ? props.to : {},
+                        href: props.link,
+                        target: props.link ? '_blank' : undefined,
+                    };
+                }
+                return {};
+            }),
         });
         return {
             ...toRefs(state),


### PR DESCRIPTION
## To Reviewers
- [ ] Skipping reviews is not a problem

## Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


## Description
In the past, internal elements were created as slots using the <router-link> component unconditionally.
However, if the slot prop is not used, a problem that appears to be a bug in the <router-link> component occurred, such as the listener not working properly.
To solve this, adding unused slot props is not a good way, so we looked for another way.

If there is no link, there is no reason to use the <router-link> component, so when there is no link, the <span> tag is used.

---
기존에는 무조건 `<router-link>` 컴포넌트를 사용하여 slot으로 내부 요소를 작성했습니다. 
그런데 slot prop을 사용하지 않으면 리스너가 제대로 동작하지 않는 등 `<router-link>` 컴포넌트의 버그로 보이는 문제가 발생했습니다.
이를 해결하기 위해 사용하지 않는 slot prop을 추가하는 것은 좋은 방법이 아니라서 다른 방법을 모색하였습니다.

link 가 없는 경우에는 `<router-link>` 컴포넌트를 사용할 이유가 없으므로, link 가 없는 경우에는 `<span>` 태그를 사용하도록 수정하였습니다.


## Things to Talk About
