### PR TITLE
feat: add more type to DynamicField & add popup type to DynamicLayout

### DIFF
--- a/src/data-display/dynamic/dynamic-field/PDynamicField.stories.mdx
+++ b/src/data-display/dynamic/dynamic-field/PDynamicField.stories.mdx
@@ -41,6 +41,7 @@ The types that can be displayed as dynamic fields are as follows.
 - state
 - enum
 - size
+- more
 - list (deprecated)
 
 <br/>
@@ -100,7 +101,8 @@ For example, ```timezone``` is not the property of the ```options``` props but o
 
 ```typescript
 interface DynamicFieldTypeOptions {
-    timezone: string;
+    timezone?: string;
+    displayKey?: string;
 }
 ```
 
@@ -481,6 +483,45 @@ interface SizeOptions extends CommonOptions {
                 <p class="font-bold text-lg">from kb to gb</p><br/>
                 <p-dynamic-field type="size" :options="{source_unit: 'KB', display_unit: 'GB'}" :data="123456789"></p-dynamic-field><br/>
                 <br/>
+            </div>
+    `,
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+
+## More Type
+It's options are:
+
+```typescript
+interface MoreOptions extends CommonOptions {
+    sub_key?: string;
+    layout: DynamicLayout;
+}
+```
+
+<Canvas>
+    <Story name="More Type">
+        {{
+            components: { PDynamicField },
+            template: `
+            <div>
+                <p-dynamic-field type="more" :options="{
+                        sub_key: 'info',
+                        layout: {
+                            type: 'popup',
+                            options: {
+                                layout: {
+                                    type: 'raw',
+                                    options: {}
+                                }
+                            }
+                        },
+                     }" :data="{ id: 'j', name: 'sulmo', info: { weight: '83.5 kg', height: '179.3cm' } }"
+                    :type-options="{ displayKey: 'name' }"
+                ></p-dynamic-field>
+                <br><br>
             </div>
     `,
         }}

--- a/src/data-display/dynamic/dynamic-field/PDynamicField.vue
+++ b/src/data-display/dynamic/dynamic-field/PDynamicField.vue
@@ -7,6 +7,7 @@
             <template #default="{value}">
                 <p-dynamic-field :options="options"
                                  :data="value"
+                                 :type="type"
                                  :type-options="typeOptions"
                                  :extra-data="extraData"
                                  :handler="handler"
@@ -37,6 +38,10 @@ import { DynamicFieldProps } from '@/data-display/dynamic/dynamic-field/type';
 import { DynamicFieldType, dynamicFieldTypes } from '@/data-display/dynamic/dynamic-field/type/field-schema';
 import PTextList from '@/others/console/text-list/PTextList.vue';
 
+const PDynamicField = () => ({
+    // eslint-disable-next-line import/no-self-import
+    component: import('./PDynamicField.vue'),
+});
 
 const RECURSIVE_TYPE = ['list', 'enum'];
 
@@ -65,12 +70,14 @@ const componentMap: Record<DynamicFieldType, AsyncComponent> = {
     list: () => ({
         component: import('./templates/list/index.vue') as Promise<ImportedComponent>,
     }),
+    more: () => ({
+        component: import('./templates/more/index.vue') as Promise<ImportedComponent>,
+    }),
 };
 
 export default defineComponent<DynamicFieldProps>({
     name: 'PDynamicField',
-    // eslint-disable-next-line import/no-self-import
-    components: { PTextList, PDynamicField: () => import('@/data-display/dynamic/dynamic-field/PDynamicField.vue') },
+    components: { PTextList, PDynamicField },
     props: {
         type: {
             type: String,

--- a/src/data-display/dynamic/dynamic-field/templates/more/index.vue
+++ b/src/data-display/dynamic/dynamic-field/templates/more/index.vue
@@ -1,7 +1,9 @@
 <template>
     <span class="p-dynamic-field-more">
         <span @click="handleClick">{{ displayData }}</span>
-        <p-dynamic-layout :type="SUPPORTED_TYPES.includes(layoutSchema.type) ? layoutSchema.type : SUPPORTED_TYPES[0]"
+        <p-dynamic-layout v-if="isInitiated"
+                          :type="SUPPORTED_TYPES.includes(layoutSchema.type) ? layoutSchema.type : SUPPORTED_TYPES[0]"
+                          :name="layoutSchema.name"
                           :options="layoutSchema.options"
                           :data="subData"
                           :type-options="{
@@ -20,8 +22,9 @@ import {
 
 import { MoreDynamicFieldProps, MoreTypeOptions } from '@/data-display/dynamic/dynamic-field/templates/more/type';
 import { MoreOptions } from '@/data-display/dynamic/dynamic-field/type/field-schema';
-import PDynamicLayout from '@/data-display/dynamic/dynamic-layout/PDynamicLayout.vue';
 import { getValueByPath } from '@/data-display/dynamic/helper';
+
+const PDynamicLayout = () => import('@/data-display/dynamic/dynamic-layout/PDynamicLayout.vue');
 
 const SUPPORTED_TYPES = ['popup'];
 export default defineComponent<MoreDynamicFieldProps>({
@@ -52,12 +55,14 @@ export default defineComponent<MoreDynamicFieldProps>({
     setup(props) {
         const state = reactive({
             layoutSchema: computed(() => props.options.layout ?? {}),
-            popupVisible: false,
             displayData: computed(() => (props.typeOptions?.displayKey ? getValueByPath(props.data, props.typeOptions.displayKey) : props.data)),
             subData: computed(() => (props.options?.sub_key ? getValueByPath(props.data, props.options.sub_key) : props.data)),
+            isInitiated: false,
+            popupVisible: false,
         });
 
         const handleClick = () => {
+            if (!state.isInitiated) state.isInitiated = true;
             state.popupVisible = true;
         };
 

--- a/src/data-display/dynamic/dynamic-field/templates/more/index.vue
+++ b/src/data-display/dynamic/dynamic-field/templates/more/index.vue
@@ -1,0 +1,83 @@
+<template>
+    <span class="p-dynamic-field-more">
+        <span @click="handleClick">{{ displayData }}</span>
+        <p-dynamic-layout :type="SUPPORTED_TYPES.includes(layoutSchema.type) ? layoutSchema.type : SUPPORTED_TYPES[0]"
+                          :options="layoutSchema.options"
+                          :data="subData"
+                          :type-options="{
+                              popupVisible
+                          }"
+                          @update-popup-visible="handleUpdatePopupVisible"
+        />
+    </span>
+</template>
+
+<script lang="ts">
+import {
+    computed,
+    defineComponent, PropType, reactive, toRefs,
+} from '@vue/composition-api';
+
+import { MoreDynamicFieldProps, MoreTypeOptions } from '@/data-display/dynamic/dynamic-field/templates/more/type';
+import { MoreOptions } from '@/data-display/dynamic/dynamic-field/type/field-schema';
+import PDynamicLayout from '@/data-display/dynamic/dynamic-layout/PDynamicLayout.vue';
+import { getValueByPath } from '@/data-display/dynamic/helper';
+
+const SUPPORTED_TYPES = ['popup'];
+export default defineComponent<MoreDynamicFieldProps>({
+    name: 'PDynamicFieldMore',
+    components: { PDynamicLayout },
+    props: {
+        options: {
+            type: Object as PropType<MoreOptions>,
+            default: () => ({}),
+        },
+        data: {
+            type: [String, Object, Array, Boolean, Number],
+            default: undefined,
+        },
+        typeOptions: {
+            type: Object as PropType<MoreTypeOptions>,
+            default: () => ({}),
+        },
+        extraData: {
+            type: Object,
+            default: () => ({}),
+        },
+        handler: {
+            type: Function,
+            default: undefined,
+        },
+    },
+    setup(props) {
+        const state = reactive({
+            layoutSchema: computed(() => props.options.layout ?? {}),
+            popupVisible: false,
+            displayData: computed(() => (props.typeOptions?.displayKey ? getValueByPath(props.data, props.typeOptions.displayKey) : props.data)),
+            subData: computed(() => (props.options?.sub_key ? getValueByPath(props.data, props.options.sub_key) : props.data)),
+        });
+
+        const handleClick = () => {
+            state.popupVisible = true;
+        };
+
+        const handleUpdatePopupVisible = (popupVisible) => {
+            state.popupVisible = popupVisible;
+        };
+
+        return {
+            ...toRefs(state),
+            handleClick,
+            handleUpdatePopupVisible,
+            SUPPORTED_TYPES,
+        };
+    },
+});
+</script>
+
+<style lang="postcss">
+.p-dynamic-field-more {
+    @apply text-blue-700;
+    cursor: pointer;
+}
+</style>

--- a/src/data-display/dynamic/dynamic-field/templates/more/type.ts
+++ b/src/data-display/dynamic/dynamic-field/templates/more/type.ts
@@ -1,0 +1,13 @@
+import {
+    DynamicFieldProps,
+    DynamicFieldTypeOptions,
+} from '@/data-display/dynamic/dynamic-field/type';
+import { MoreOptions } from '@/data-display/dynamic/dynamic-field/type/field-schema';
+
+
+export type MoreTypeOptions = Pick<DynamicFieldTypeOptions, 'displayKey'>;
+
+export type MoreDynamicFieldProps = DynamicFieldProps<
+    MoreOptions,
+    MoreTypeOptions
+    >

--- a/src/data-display/dynamic/dynamic-field/type/field-schema.ts
+++ b/src/data-display/dynamic/dynamic-field/type/field-schema.ts
@@ -1,6 +1,8 @@
 /** Metadata schema types for Dynamic field */
+// eslint-disable-next-line import/no-cycle
+import { DynamicLayout } from '@/data-display/dynamic/dynamic-layout/type/layout-schema';
 
-export const dynamicFieldTypes = ['text', 'badge', 'datetime', 'state', 'enum', 'size', 'dict', 'list'];
+export const dynamicFieldTypes = ['text', 'badge', 'datetime', 'state', 'enum', 'size', 'dict', 'list', 'more'];
 
 export type DynamicFieldType = typeof dynamicFieldTypes[number];
 
@@ -50,6 +52,11 @@ export interface StateOptions extends CommonOptions {
     text_color?: string;
 }
 
+export interface MoreOptions extends CommonOptions {
+    sub_key?: string;
+    layout: DynamicLayout;
+}
+
 export interface EnumItem {
     name?: string;
     type: DynamicFieldType;
@@ -85,6 +92,7 @@ export type DynamicFieldOptions =
     | StateOptions
     | TextOptions
     | SizeOptions
+    | MoreOptions
 
 
 export interface DynamicField {

--- a/src/data-display/dynamic/dynamic-field/type/index.ts
+++ b/src/data-display/dynamic/dynamic-field/type/index.ts
@@ -6,6 +6,7 @@ import {
 
 export interface DynamicFieldTypeOptions {
     timezone?: string;
+    displayKey?: string;
 }
 
 export interface DynamicFieldProps<Options = DynamicFieldOptions, TypeOptions = DynamicFieldTypeOptions, ExtraData = any> {

--- a/src/data-display/dynamic/dynamic-layout/PDynamicLayout.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/PDynamicLayout.stories.mdx
@@ -85,7 +85,7 @@ export const Template = (args, { argTypes }) => ({
 | raw | ```root_path?: string translation_id?: string``` |
 | markdown | ```translation_id?: string, markdown: string``` or <br/> ```markdown: { en: string, ko: string }``` |
 | html | ```root_path?: string, translation_id?: string``` |
-| popup | ```translation_id?: string, layout?: DynamicLayout``` |
+| popup | ```sub_key?: string, layout?: DynamicLayout``` |
 | list | ```root_path?: string, layouts: DynamicLayout[]``` |
 
 
@@ -101,6 +101,7 @@ export const Template = (args, { argTypes }) => ({
 | raw | - |
 | markdown | - |
 | html | - |
+| popup | - |
 | list | The fetch options required for all layouts in the list are applied collectively. |
 
 <br/>

--- a/src/data-display/dynamic/dynamic-layout/PDynamicLayout.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/PDynamicLayout.stories.mdx
@@ -29,6 +29,7 @@ export const Template = (args, { argTypes }) => ({
                                   keyItemSets,
                                   valueHandlerMap,
                                   language,
+                                  popupVisible,
                               }"
                               :fetch-options="{
                                   sortBy,
@@ -38,11 +39,12 @@ export const Template = (args, { argTypes }) => ({
                                   queryTags,
                                   searchText
                               }"
-                               class="w-full"
-                               @fetch="onFetch"
-                                @select="onSelect"
-                                @export="onExport"
-                                @click-settings="onClickSettings"
+                              class="w-full"
+                              @fetch="onFetch"
+                              @select="onSelect"
+                              @export="onExport"
+                              @click-settings="onClickSettings"
+                              @update-popup-visible="onUpdatePopupVisible"
             >
             </p-dynamic-layout>
     `,
@@ -65,6 +67,7 @@ export const Template = (args, { argTypes }) => ({
 | raw | - |
 | markdown | - |
 | html | - |
+| popup | modal view |
 | list | list(<dynamic_layout>) |
 
 <br/>
@@ -82,6 +85,7 @@ export const Template = (args, { argTypes }) => ({
 | raw | ```root_path?: string translation_id?: string``` |
 | markdown | ```translation_id?: string, markdown: string``` or <br/> ```markdown: { en: string, ko: string }``` |
 | html | ```root_path?: string, translation_id?: string``` |
+| popup | ```translation_id?: string, layout?: DynamicLayout``` |
 | list | ```root_path?: string, layouts: DynamicLayout[]``` |
 
 
@@ -126,6 +130,7 @@ Each type of dynamic layout corresponds to each component as the table below.<br
 | raw | Raw |
 | markdown | Markdown |
 | html | - |
+| popup | ButtonModal |
 | list | - |
 
 <br/>
@@ -142,6 +147,7 @@ Each type of dynamic layout corresponds to each component as the table below.<br
 | raw | ```loading``` |
 | markdown | ```language``` |
 | html | - |
+| popup | ```popupVisible``` |
 | list | all |
 
 <br/>
@@ -150,19 +156,20 @@ Each type of dynamic layout corresponds to each component as the table below.<br
 ## Type Options Description
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
-| loading | boolean | ```false``` | Used to display loading spinner. |
-| totalCount | number | ```0``` | Used to calculate pagination, displaying count next to the title. |
-| timezone | string |```'UTC'``` | Used to display datetime. |
-| selectIndex | number[] |```[]``` | Used to initiate selectIndex of tables. Works only when 'selectable' is ```true```. |
-| selectable | boolean | ```false``` | Used to make tables selectable. |
-| multiSelect | boolean | ```true``` | Used to make tables multi-selectable. Works only when 'selectable' is ```true```. |
-| invalid | boolean | ```false``` | Used to display invalid style. |
-| colCopy | boolean | ```false``` | Used to on/off each column copy. |
-| excelVisible | boolean | ```false``` | Used to on/off export button. |
-| settingsVisible | boolean | ```false``` | Used to on/off settings button. |
+| loading | boolean | ```false``` | Displays loading spinner. |
+| totalCount | number | ```0``` | Calculate pagination, displaying count next to the title. |
+| timezone | string |```'UTC'``` | Display datetime. |
+| selectIndex | number[] |```[]``` | Initiate selectIndex of tables. Works only when 'selectable' is ```true```. |
+| selectable | boolean | ```false``` | Make tables selectable. |
+| multiSelect | boolean | ```true``` | Make tables multi-selectable. Works only when 'selectable' is ```true```. |
+| invalid | boolean | ```false``` | Display invalid style. |
+| colCopy | boolean | ```false``` | Determine whether to each column copiable or not. |
+| excelVisible | boolean | ```false``` | Determine whether to show export button or not. |
+| settingsVisible | boolean | ```false``` | Determine whether to show settings button or not. |
 | keyItemSets | KeyItemSet[] |```options.fields``` or ```[]``` | Only for query-search-table's key items. |
 | valueHandlerMap | ValueHandlerMap |```{}``` | Only for query-search-table's value handler map. |
 | language | string | ```'en'``` | NOT supported yet except markdown type. |
+| popupVisible | boolean | ```false``` | Determine whether to show popup modal or not. Supported only for `popup` type. |
 
 ```typescript
 interface DynamicLayoutTypeOptions {
@@ -179,6 +186,7 @@ interface DynamicLayoutTypeOptions {
     keyItemSets?: KeyItemSet[];
     valueHandlerMap?: ValueHandlerMap;
     language?: string;
+    popupVisible?: boolean;
 }
 ```
 
@@ -190,6 +198,7 @@ interface DynamicLayoutTypeOptions {
 | select | Emitted when row(item) has been selected. |
 | export | Emitted when clicked export button. |
 | click-settings | Emitted when clicked settings button. |
+| update-popup-visible | Emitted when popupVisible typeOptions is updated. |
 
 <br/>
 <br/>
@@ -202,6 +211,7 @@ interface DynamicLayoutEventListeners {
     select: (selectIndex: number[], layoutName?: string, layoutIndex?: number) => void|Promise<void>;
     export: (layoutName?: string, layoutIndex?: number) => void|Promise<void>;
     'click-settings': (layoutName?: string, layoutIndex?: number) => void|Promise<void>;
+    'update-popup-visible': (popupVisible?: boolean) => void|Promise<void>;
 }
 ```
 
@@ -211,6 +221,7 @@ interface DynamicLayoutEventListeners {
 | selectIndex | Selected row(item) indexes. |
 | layoutName | Name props. Only provided when layout type is 'list'. |
 | layoutIndex | Layout index. Only provided when layout type is 'list'. |
+| popupVisible | Is popup visible or not. |
 
 <br/>
 <br/>
@@ -226,6 +237,7 @@ interface DynamicLayoutEventListeners {
 | raw | - |
 | markdown | - |
 | html | - |
+| popup | update-popup-visible |
 | list | fetch, select, export |
 
 <br/>

--- a/src/data-display/dynamic/dynamic-layout/PDynamicLayout.vue
+++ b/src/data-display/dynamic/dynamic-layout/PDynamicLayout.vue
@@ -16,6 +16,7 @@
 
 <script lang="ts">
 import {
+    defineComponent,
     onMounted, reactive, toRefs, watch,
 } from '@vue/composition-api';
 import { AsyncComponent } from 'vue';
@@ -55,8 +56,11 @@ const componentMap: Record<DynamicLayoutType, AsyncComponent> = {
     html: () => ({
         component: import('./templates/html/index.vue') as Promise<ImportedComponent>,
     }),
+    popup: () => ({
+        component: import('./templates/popup/index.vue') as Promise<ImportedComponent>,
+    }),
 };
-export default {
+export default defineComponent({
     name: 'PDynamicLayout',
     components: { PSkeleton },
     props: {
@@ -119,5 +123,5 @@ export default {
             ...toRefs(state),
         };
     },
-};
+});
 </script>

--- a/src/data-display/dynamic/dynamic-layout/PDynamicLayoutPlayground.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/PDynamicLayoutPlayground.stories.mdx
@@ -29,6 +29,7 @@ export const Template = (args, { argTypes }) => ({
                                   keyItemSets,
                                   valueHandlerMap,
                                   language,
+                                  popupVisible
                               }"
                               :fetch-options="{
                                   sortBy,
@@ -43,6 +44,7 @@ export const Template = (args, { argTypes }) => ({
                                 @select="onSelect"
                                 @export="onExport"
                                 @click-settings="onClickSettings"
+                                @update-popup-visible="onUpdatePopupVisible"
             >
             </p-dynamic-layout>
     `,

--- a/src/data-display/dynamic/dynamic-layout/mock.ts
+++ b/src/data-display/dynamic/dynamic-layout/mock.ts
@@ -850,6 +850,22 @@ Right aligned columns
         },
         data: {},
     },
+    popup: {
+        options: {
+            layout: {
+                name: 'Pop Up',
+                type: 'raw',
+                options: {},
+            },
+        },
+        data: [
+            { key: 'replica_set', value: '2', data: { array: [{ id: 'a' }] } },
+            { key: 'Name', value: 'mongodb-s2d3-dev', data: { array: [{ id: 'b' }] } },
+            { key: 'rs_type', value: 'arbiter', data: { array: [{ id: 'c' }, { id: 'cccccc' }] } },
+            { key: 'rs_primary', value: 'false', data: { array: [{ id: 'd' }, { id: 'ddd' }] } },
+            { key: 'server_type', value: 'mongodb', data: { array: [] } },
+        ],
+    },
 };
 
 export const getQueryTags = () => getToolboxQueryTags();

--- a/src/data-display/dynamic/dynamic-layout/mock.ts
+++ b/src/data-display/dynamic/dynamic-layout/mock.ts
@@ -665,6 +665,22 @@ export default {
                     name: 'Hello',
                     type: 'badge',
                 },
+                {
+                    key: 'value',
+                    name: 'More',
+                    type: 'more',
+                    options: {
+                        sub_key: 'data',
+                        layout: {
+                            type: 'popup',
+                            options: {
+                                layout: {
+                                    type: 'raw',
+                                },
+                            },
+                        },
+                    },
+                },
             ],
         },
         data: [

--- a/src/data-display/dynamic/dynamic-layout/story-helper.ts
+++ b/src/data-display/dynamic/dynamic-layout/story-helper.ts
@@ -1,6 +1,7 @@
 import { ArgTypes } from '@storybook/addons';
 
 import mock, { getQueryTags } from '@/data-display/dynamic/dynamic-layout/mock';
+import { dynamicLayoutTypes } from '@/data-display/dynamic/dynamic-layout/type/layout-schema';
 
 export const getDynamicLayoutArgTypes = (): ArgTypes => ({
     name: {
@@ -25,19 +26,19 @@ export const getDynamicLayoutArgTypes = (): ArgTypes => ({
         name: 'type',
         type: { name: 'string' },
         description: 'Type of dynamic layout',
-        defaultValue: 'item',
+        defaultValue: dynamicLayoutTypes[0],
         table: {
             type: {
                 summary: 'string',
             },
             category: 'props',
             defaultValue: {
-                summary: 'item',
+                summary: dynamicLayoutTypes[0],
             },
         },
         control: {
             type: 'select',
-            options: ['item', 'html', 'markdown', 'query-search-table', 'raw-table', 'table', 'simple-table', 'raw'],
+            options: dynamicLayoutTypes,
         },
     },
     options: {
@@ -348,6 +349,23 @@ export const getDynamicLayoutArgTypes = (): ArgTypes => ({
             type: 'object',
         },
     },
+    popupVisible: {
+        name: 'popupVisible',
+        type: { name: 'boolean' },
+        defaultValue: false,
+        table: {
+            type: {
+                summary: 'boolean',
+            },
+            category: 'typeOptions',
+            defaultValue: {
+                summary: false,
+            },
+        },
+        control: {
+            type: 'boolean',
+        },
+    },
     // fetch options
     sortBy: {
         name: 'sortBy',
@@ -495,6 +513,19 @@ export const getDynamicLayoutArgTypes = (): ArgTypes => ({
     onClickSettings: {
         name: 'click-settings',
         description: 'An event emitted by an settings button click action.',
+        table: {
+            type: {
+                summary: null,
+            },
+            category: 'events',
+            defaultValue: {
+                summary: null,
+            },
+        },
+    },
+    onUpdatePopupVisible: {
+        name: 'update-popup-visible',
+        description: 'An event emitted when popupVisible typeOptions is updated.',
         table: {
             type: {
                 summary: null,

--- a/src/data-display/dynamic/dynamic-layout/templates/html/html.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/templates/html/html.stories.mdx
@@ -45,7 +45,7 @@ export const Template = (args, { argTypes }) => ({
 | layouts | X |
 | search | X |
 | disable_search | X |
-
+| layout | X |
 
 ## Supported Fetch Options
 

--- a/src/data-display/dynamic/dynamic-layout/templates/html/html.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/templates/html/html.stories.mdx
@@ -76,6 +76,7 @@ export const Template = (args, { argTypes }) => ({
 | keyItemSets | X |
 | valueHandlerMap | X |
 | language | X |
+| popupVisible | X |
 
 
 ## Supported Events
@@ -86,6 +87,7 @@ export const Template = (args, { argTypes }) => ({
 | select | X |
 | export | X |
 | click-settings | X |
+| update-popup-visible | X |
 
 
 <br/>

--- a/src/data-display/dynamic/dynamic-layout/templates/item/item.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/templates/item/item.stories.mdx
@@ -76,6 +76,7 @@ export const Template = (args, { argTypes }) => ({
 | keyItemSets | X |
 | valueHandlerMap | X |
 | language | X |
+| popupVisible | X |
 
 
 ## Supported Events
@@ -86,6 +87,7 @@ export const Template = (args, { argTypes }) => ({
 | select | X |
 | export | X |
 | click-settings | X |
+| update-popup-visible | O |
 
 <br/>
 <br/>

--- a/src/data-display/dynamic/dynamic-layout/templates/item/item.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/templates/item/item.stories.mdx
@@ -44,6 +44,7 @@ export const Template = (args, { argTypes }) => ({
 | layouts | X |
 | search | X |
 | disable_search | X |
+| layout | X |
 
 
 ## Supported Fetch Options

--- a/src/data-display/dynamic/dynamic-layout/templates/list/list.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/templates/list/list.stories.mdx
@@ -101,6 +101,7 @@ export const Template = (args, { argTypes }) => ({
 | keyItemSets | O |
 | valueHandlerMap | O |
 | language | O |
+| popupVisible | X |
 
 
 ## Supported Events
@@ -111,6 +112,7 @@ export const Template = (args, { argTypes }) => ({
 | select | O |
 | export | O |
 | click-settings | O |
+| update-popup-visible | X |
 
 list type's event parameters are different: <br/>
 

--- a/src/data-display/dynamic/dynamic-layout/templates/markdown/markdown.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/templates/markdown/markdown.stories.mdx
@@ -76,6 +76,7 @@ export const Template = (args, { argTypes }) => ({
 | keyItemSets | X |
 | valueHandlerMap | X |
 | language | O |
+| popupVisible | X |
 
 
 ## Supported Events
@@ -85,6 +86,7 @@ export const Template = (args, { argTypes }) => ({
 | select | X |
 | export | X |
 | click-settings | X |
+| update-popup-visible | X |
 
 <br/>
 <br/>

--- a/src/data-display/dynamic/dynamic-layout/templates/markdown/markdown.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/templates/markdown/markdown.stories.mdx
@@ -45,6 +45,7 @@ export const Template = (args, { argTypes }) => ({
 | layouts | X |
 | search | X |
 | disable_search | X |
+| layout | X |
 
 
 ## Supported Fetch Options

--- a/src/data-display/dynamic/dynamic-layout/templates/popup/index.vue
+++ b/src/data-display/dynamic/dynamic-layout/templates/popup/index.vue
@@ -1,0 +1,70 @@
+<template>
+    <div class="p-dynamic-layout-popup">
+        <p-button-modal v-model="modalVisible">
+            <template #body>
+                <p-dynamic-layout :type="layoutSchema.type"
+                                  :options="layoutSchema.options"
+                                  :data="data"
+                />
+            </template>
+        </p-button-modal>
+    </div>
+</template>
+
+<script lang="ts">
+import {
+    computed, defineComponent, PropType,
+    reactive, toRefs,
+} from '@vue/composition-api';
+
+import { DynamicFieldHandler } from '@/data-display/dynamic/dynamic-field/type';
+import PDynamicLayout from '@/data-display/dynamic/dynamic-layout/PDynamicLayout.vue';
+import { PopupDynamicLayoutProps } from '@/data-display/dynamic/dynamic-layout/templates/popup/type';
+import { DynamicLayoutFetchOptions, DynamicLayoutTypeOptions } from '@/data-display/dynamic/dynamic-layout/type';
+import { PopupOptions } from '@/data-display/dynamic/dynamic-layout/type/layout-schema';
+import PButtonModal from '@/feedbacks/modals/button-modal/PButtonModal.vue';
+
+export default defineComponent<PopupDynamicLayoutProps>({
+    name: 'PDynamicLayoutPopup',
+    components: {
+        PButtonModal,
+        PDynamicLayout,
+    },
+    props: {
+        name: {
+            type: String,
+            required: true,
+        },
+        options: {
+            type: Object as PropType<PopupOptions>,
+            default: () => ({}),
+        },
+        data: {
+            type: [Object, Array, String],
+            default: undefined,
+        },
+        fetchOptions: {
+            type: Object as PropType<DynamicLayoutFetchOptions|undefined>,
+            default: undefined,
+        },
+        typeOptions: {
+            type: Object as PropType<DynamicLayoutTypeOptions|undefined>,
+            default: undefined,
+        },
+        fieldHandler: {
+            type: Function as PropType<DynamicFieldHandler|undefined>,
+            default: undefined,
+        },
+    },
+    setup(props) {
+        const state = reactive({
+            layoutSchema: computed(() => props.options.layout ?? {}),
+            modalVisible: true,
+        });
+
+        return {
+            ...toRefs(state),
+        };
+    },
+});
+</script>

--- a/src/data-display/dynamic/dynamic-layout/templates/popup/index.vue
+++ b/src/data-display/dynamic/dynamic-layout/templates/popup/index.vue
@@ -1,6 +1,10 @@
 <template>
     <div class="p-dynamic-layout-popup">
-        <p-button-modal :title="name" :visible="popupVisible" @update:visible="handleUpdateVisible">
+        <p-button-modal v-if="isInitiated"
+                        :header-title="name"
+                        :visible="popupVisible"
+                        @update:visible="handleUpdateVisible"
+        >
             <template #body>
                 <p-dynamic-layout :type="layoutSchema.type"
                                   :options="layoutSchema.options"
@@ -22,7 +26,8 @@ import PDynamicLayout from '@/data-display/dynamic/dynamic-layout/PDynamicLayout
 import { PopupDynamicLayoutProps } from '@/data-display/dynamic/dynamic-layout/templates/popup/type';
 import { DynamicLayoutFetchOptions, DynamicLayoutTypeOptions } from '@/data-display/dynamic/dynamic-layout/type';
 import { PopupOptions } from '@/data-display/dynamic/dynamic-layout/type/layout-schema';
-import PButtonModal from '@/feedbacks/modals/button-modal/PButtonModal.vue';
+
+const PButtonModal = () => import('@/feedbacks/modals/button-modal/PButtonModal.vue');
 
 export default defineComponent<PopupDynamicLayoutProps>({
     name: 'PDynamicLayoutPopup',
@@ -60,16 +65,18 @@ export default defineComponent<PopupDynamicLayoutProps>({
         const state = reactive({
             layoutSchema: computed(() => props.options.layout ?? {}),
             popupVisible: props.typeOptions?.popupVisible,
+            isInitiated: props.typeOptions?.popupVisible,
         });
 
         const handleUpdateVisible = (popupVisible) => {
+            if (!state.isInitiated) state.isInitiated = true;
             state.popupVisible = popupVisible;
             emit('update-popup-visible', popupVisible);
         };
         watch(() => props.typeOptions, (typeOptions) => {
             if (typeOptions?.popupVisible !== state.popupVisible) {
+                if (!state.isInitiated) state.isInitiated = true;
                 state.popupVisible = typeOptions?.popupVisible;
-                // emit('update-popup-visible', state.popupVisible);
             }
         });
 

--- a/src/data-display/dynamic/dynamic-layout/templates/popup/index.vue
+++ b/src/data-display/dynamic/dynamic-layout/templates/popup/index.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="p-dynamic-layout-popup">
-        <p-button-modal v-model="modalVisible">
+        <p-button-modal :title="name" :visible="popupVisible" @update:visible="handleUpdateVisible">
             <template #body>
                 <p-dynamic-layout :type="layoutSchema.type"
                                   :options="layoutSchema.options"
@@ -14,7 +14,7 @@
 <script lang="ts">
 import {
     computed, defineComponent, PropType,
-    reactive, toRefs,
+    reactive, toRefs, watch,
 } from '@vue/composition-api';
 
 import { DynamicFieldHandler } from '@/data-display/dynamic/dynamic-field/type';
@@ -56,14 +56,26 @@ export default defineComponent<PopupDynamicLayoutProps>({
             default: undefined,
         },
     },
-    setup(props) {
+    setup(props, { emit }) {
         const state = reactive({
             layoutSchema: computed(() => props.options.layout ?? {}),
-            modalVisible: true,
+            popupVisible: props.typeOptions?.popupVisible,
+        });
+
+        const handleUpdateVisible = (popupVisible) => {
+            state.popupVisible = popupVisible;
+            emit('update-popup-visible', popupVisible);
+        };
+        watch(() => props.typeOptions, (typeOptions) => {
+            if (typeOptions?.popupVisible !== state.popupVisible) {
+                state.popupVisible = typeOptions?.popupVisible;
+                // emit('update-popup-visible', state.popupVisible);
+            }
         });
 
         return {
             ...toRefs(state),
+            handleUpdateVisible,
         };
     },
 });

--- a/src/data-display/dynamic/dynamic-layout/templates/popup/popup.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/templates/popup/popup.stories.mdx
@@ -1,10 +1,11 @@
 import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs/blocks';
 import PDynamicLayout from '@/data-display/dynamic/dynamic-layout/PDynamicLayout.vue';
 import {i18n} from '@/translations'
-import { getDynamicLayoutRawArgTypes } from '@/data-display/dynamic/dynamic-layout/templates/raw/story-helper';
+import mock from '@/data-display/dynamic/dynamic-layout/mock.ts'
+import { getDynamicLayoutPopupArgTypes } from '@/data-display/dynamic/dynamic-layout/templates/popup/story-helper';
 
-<Meta title='Data Display/Dynamic/Dynamic Layout/- Raw'
-      argTypes={getDynamicLayoutRawArgTypes()}/>
+<Meta title='Data Display/Dynamic/Dynamic Layout/- Popup'
+      argTypes={getDynamicLayoutPopupArgTypes()}/>
 
 
 export const Template = (args, { argTypes }) => ({
@@ -12,17 +13,15 @@ export const Template = (args, { argTypes }) => ({
     components: { PDynamicLayout },
     i18n,
     template: `
-      <p-dynamic-layout :name="name" type="raw"
+      <p-dynamic-layout :name="name" type="popup"
                           :options="options"
                           :data="data"
                           :type-options="{
-                              loading,
                           }"
                           :fetch-options="{
                           }"
                            class="w-full"
-            >
-        </p-dynamic-layout>
+      />
     `,
     setup() {
         return {}
@@ -30,7 +29,7 @@ export const Template = (args, { argTypes }) => ({
 });
 
 
-# Raw Type
+# Markdown Type
 <br/>
 <br/>
 
@@ -41,11 +40,11 @@ export const Template = (args, { argTypes }) => ({
 | root_path | O |
 | translation_id | O |
 | fields | X |
-| markdown | X |
+| markdown | O |
 | layouts | X |
 | search | X |
 | disable_search | X |
-| layout | X |
+| layout | O |
 
 
 ## Supported Fetch Options
@@ -59,12 +58,11 @@ export const Template = (args, { argTypes }) => ({
 | searchText | X |
 | queryTags | X |
 
-
 ## Supported Type Options
 
 | Type Option Name | Supported |
 | ---- | ---- |
-| loading | O |
+| loading | X |
 | totalCount | X |
 | timezone | X |
 | selectIndex | X |
@@ -80,7 +78,6 @@ export const Template = (args, { argTypes }) => ({
 
 
 ## Supported Events
-
 | Event Name | Supported |
 | ---------- | ----------- |
 | fetch | X |
@@ -88,9 +85,10 @@ export const Template = (args, { argTypes }) => ({
 | export | X |
 | click-settings | X |
 
+<br/>
+<br/>
 
-<br/>
-<br/>
+
 
 ## Playground
 

--- a/src/data-display/dynamic/dynamic-layout/templates/popup/popup.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/templates/popup/popup.stories.mdx
@@ -17,6 +17,7 @@ export const Template = (args, { argTypes }) => ({
                           :options="options"
                           :data="data"
                           :type-options="{
+                              popupVisible
                           }"
                           :fetch-options="{
                           }"

--- a/src/data-display/dynamic/dynamic-layout/templates/popup/popup.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/templates/popup/popup.stories.mdx
@@ -75,6 +75,7 @@ export const Template = (args, { argTypes }) => ({
 | keyItemSets | X |
 | valueHandlerMap | X |
 | language | X |
+| popupVisible | O |
 
 
 ## Supported Events
@@ -84,6 +85,7 @@ export const Template = (args, { argTypes }) => ({
 | select | X |
 | export | X |
 | click-settings | X |
+| update-popup-visible | O |
 
 <br/>
 <br/>

--- a/src/data-display/dynamic/dynamic-layout/templates/popup/story-helper.ts
+++ b/src/data-display/dynamic/dynamic-layout/templates/popup/story-helper.ts
@@ -13,5 +13,6 @@ export const getDynamicLayoutPopupArgTypes = (): ArgTypes => {
         name: argTypes.name,
         options: argTypes.options,
         data: argTypes.data,
+        popupVisible: argTypes.popupVisible,
     };
 };

--- a/src/data-display/dynamic/dynamic-layout/templates/popup/story-helper.ts
+++ b/src/data-display/dynamic/dynamic-layout/templates/popup/story-helper.ts
@@ -1,0 +1,17 @@
+import { ArgTypes } from '@storybook/addons';
+
+import mock from '@/data-display/dynamic/dynamic-layout/mock';
+import { getDynamicLayoutArgTypes } from '@/data-display/dynamic/dynamic-layout/story-helper';
+
+export const getDynamicLayoutPopupArgTypes = (): ArgTypes => {
+    const argTypes = getDynamicLayoutArgTypes();
+
+    argTypes.options.defaultValue = mock.popup.options;
+    argTypes.data.defaultValue = mock.popup.data;
+
+    return {
+        name: argTypes.name,
+        options: argTypes.options,
+        data: argTypes.data,
+    };
+};

--- a/src/data-display/dynamic/dynamic-layout/templates/popup/type.ts
+++ b/src/data-display/dynamic/dynamic-layout/templates/popup/type.ts
@@ -1,0 +1,7 @@
+import {
+    DynamicLayoutProps,
+} from '@/data-display/dynamic/dynamic-layout/type';
+import { PopupOptions } from '@/data-display/dynamic/dynamic-layout/type/layout-schema';
+
+
+export type PopupDynamicLayoutProps = DynamicLayoutProps<PopupOptions>

--- a/src/data-display/dynamic/dynamic-layout/templates/query-search-table/query-search-table.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/templates/query-search-table/query-search-table.stories.mdx
@@ -101,6 +101,7 @@ export const Template = (args, { argTypes }) => ({
 | keyItemSets | O |
 | valueHandlerMap | O |
 | language | O |
+| popupVisible | X |
 
 
 ## Supported Events
@@ -110,6 +111,7 @@ export const Template = (args, { argTypes }) => ({
 | select | O |
 | export | O |
 | click-settings | O |
+| update-popup-visible | X |
 
 <br/>
 <br/>

--- a/src/data-display/dynamic/dynamic-layout/templates/query-search-table/query-search-table.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/templates/query-search-table/query-search-table.stories.mdx
@@ -69,6 +69,7 @@ export const Template = (args, { argTypes }) => ({
 | layouts | X |
 | search | O |
 | disable_search | O |
+| layout | X |
 
 
 ## Supported Fetch Options

--- a/src/data-display/dynamic/dynamic-layout/templates/raw-table/raw-table.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/templates/raw-table/raw-table.stories.mdx
@@ -63,6 +63,7 @@ export const Template = (args, { argTypes }) => ({
 | layouts | X |
 | search | X |
 | disable_search | O |
+| layout | X |
 
 
 ## Supported Fetch Options

--- a/src/data-display/dynamic/dynamic-layout/templates/raw-table/raw-table.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/templates/raw-table/raw-table.stories.mdx
@@ -95,6 +95,8 @@ export const Template = (args, { argTypes }) => ({
 | keyItemSets | X |
 | valueHandlerMap | X |
 | language | X |
+| popupVisible | X |
+
 
 ## Supported Events
 | Event Name | Supported |
@@ -103,6 +105,7 @@ export const Template = (args, { argTypes }) => ({
 | select | O |
 | export | O |
 | click-settings | X |
+| update-popup-visible | X |
 
 <br/>
 <br/>

--- a/src/data-display/dynamic/dynamic-layout/templates/raw/raw.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/templates/raw/raw.stories.mdx
@@ -77,6 +77,7 @@ export const Template = (args, { argTypes }) => ({
 | keyItemSets | X |
 | valueHandlerMap | X |
 | language | X |
+| popupVisible | X |
 
 
 ## Supported Events
@@ -87,6 +88,7 @@ export const Template = (args, { argTypes }) => ({
 | select | X |
 | export | X |
 | click-settings | X |
+| update-popup-visible | X |
 
 
 <br/>

--- a/src/data-display/dynamic/dynamic-layout/templates/simple-table/simple-table.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/templates/simple-table/simple-table.stories.mdx
@@ -48,6 +48,7 @@ export const Template = (args, { argTypes }) => ({
 | layouts | X |
 | search | X |
 | disable_search | X |
+| layout | X |
 
 
 ## Supported Fetch Options

--- a/src/data-display/dynamic/dynamic-layout/templates/simple-table/simple-table.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/templates/simple-table/simple-table.stories.mdx
@@ -87,6 +87,7 @@ export const Template = (args, { argTypes }) => ({
 | keyItemSets | X |
 | valueHandlerMap | X |
 | language | X |
+| popupVisible | X |
 
 
 ## Supported Events
@@ -97,6 +98,7 @@ export const Template = (args, { argTypes }) => ({
 | select | X |
 | export | X |
 | click-settings | X |
+| update-popup-visible | X |
 
 <br/>
 <br/>

--- a/src/data-display/dynamic/dynamic-layout/templates/table/table.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/templates/table/table.stories.mdx
@@ -95,6 +95,7 @@ export const Template = (args, { argTypes }) => ({
 | keyItemSets | X |
 | valueHandlerMap | X |
 | language | X |
+| popupVisible | X |
 
 
 ## Supported Events
@@ -105,6 +106,7 @@ export const Template = (args, { argTypes }) => ({
 | select | O |
 | export | O |
 | click-settings | O |
+| update-popup-visible | X |
 
 <br/>
 <br/>

--- a/src/data-display/dynamic/dynamic-layout/templates/table/table.stories.mdx
+++ b/src/data-display/dynamic/dynamic-layout/templates/table/table.stories.mdx
@@ -63,6 +63,7 @@ export const Template = (args, { argTypes }) => ({
 | layouts | X |
 | search | X |
 | disable_search | O |
+| layout | X |
 
 
 ## Supported Fetch Options

--- a/src/data-display/dynamic/dynamic-layout/type/index.ts
+++ b/src/data-display/dynamic/dynamic-layout/type/index.ts
@@ -31,6 +31,7 @@ export interface DynamicLayoutTypeOptions {
     keyItemSets?: KeyItemSet[];
     valueHandlerMap?: ValueHandlerMap;
     language?: string;
+    popupVisible?: boolean;
 }
 
 export interface DynamicLayoutProps<

--- a/src/data-display/dynamic/dynamic-layout/type/layout-schema.ts
+++ b/src/data-display/dynamic/dynamic-layout/type/layout-schema.ts
@@ -31,7 +31,7 @@ export type SearchSchema = SearchKeyGroup;
 /** Metadata schema types for Dynamic layout */
 export const dynamicLayoutTypes = [
     'item', 'simple-table', 'table', 'query-search-table',
-    'raw', 'markdown', 'list', 'raw-table', 'html',
+    'raw', 'markdown', 'list', 'raw-table', 'html', 'popup',
 ];
 export type DynamicLayoutType = typeof dynamicLayoutTypes[number];
 
@@ -75,14 +75,19 @@ export interface MarkdownOptions extends CommonOptions {
     };
 }
 
+export interface PopupOptions extends CommonOptions {
+    layout: DynamicLayout
+}
+
 export interface ListOptions extends CommonOptions {
     layouts: DynamicLayout[];
 }
 
+
 export interface DynamicLayoutOptions extends
     ItemOptions, SimpleTableOptions, TableOptions,
     QuerySearchTableOptions, RawOptions, MarkdownOptions,
-    RawTableOptions, HtmlOptions, ListOptions {}
+    RawTableOptions, HtmlOptions, PopupOptions, ListOptions {}
 
 
 export interface DynamicLayout {

--- a/src/data-display/dynamic/dynamic-layout/type/layout-schema.ts
+++ b/src/data-display/dynamic/dynamic-layout/type/layout-schema.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-cycle
 import { DynamicField } from '@/data-display/dynamic/dynamic-field/type/field-schema';
 import { KeyDataType } from '@/inputs/search/query-search/type';
 


### PR DESCRIPTION
## To Reviewers
- [ ] Skipping reviews is not a problem

## Type of Change
- [x] New feature
- [ ] Bug fixes
- [ ] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


## Description

### `more` type is added to DynamicField
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/26986739/177276938-05f5a5a2-6cbe-4b81-afdc-c3e0cf2e0d34.png">
<img width="1055" alt="image" src="https://user-images.githubusercontent.com/26986739/177276956-2749d1d5-2736-4395-8e74-95a5ea8b3d2c.png">

### `displayKey` is added to DynamicField typeOptions
<img width="1046" alt="image" src="https://user-images.githubusercontent.com/26986739/177276876-c3f486c1-af1e-4b24-b077-b5642f34530a.png">

### `popup` type is added to DynamicLayout
![image](https://user-images.githubusercontent.com/26986739/177278202-165864ec-4f8f-4167-832f-8c1a3ad84b43.png)

### `popupVisible` is added to typeOptions and `update-popup-visible` event is added in DynamicLayout
<img width="799" alt="image" src="https://user-images.githubusercontent.com/26986739/177277652-e1e692ab-9d81-4af9-95e2-001c673ae670.png">
<img width="796" alt="스크린샷 2022-07-05 오후 4 51 29" src="https://user-images.githubusercontent.com/26986739/177278002-9950a602-522c-471d-9e21-bc37a26268e5.png">


## Things to Talk About
