### PR TITLE
feat(query search): make only !. != operators available in null case

### DIFF
--- a/src/inputs/search/query-search/PQuerySearch.vue
+++ b/src/inputs/search/query-search/PQuerySearch.vue
@@ -310,11 +310,11 @@ export default defineComponent({
         };
 
         /* Event triggers */
-        const emitSearch = (valueItem: ValueItem) => {
+        const emitSearch = (valueItem: ValueItem, fixedOperator?: OperatorType) => {
             let queryItem: QueryItem|null = {
                 key: state.rootKey,
                 value: valueItem,
-                operator: state.operator,
+                operator: fixedOperator ?? state.operator,
             };
 
             if (formatterMap[state.rootKey?.dataType]) {
@@ -358,7 +358,8 @@ export default defineComponent({
             if (state.currentDataType === 'object') {
                 if (state.searchText) await findAndSetKey(state.searchText, false);
             } else if (state.rootKey) {
-                if (state.searchText === '') emitSearch({ label: 'Null', name: null });
+                // In null case, only '=', '!=' operators are available.
+                if (state.searchText === '') emitSearch({ label: 'Null', name: null }, state.operator.startsWith('!') ? '!=' : '=');
                 else emitSearch({ label: state.searchText, name: state.searchText });
             } else if (state.searchText) emitSearch({ label: state.searchText, name: state.searchText });
         };

--- a/src/navigation/toolbox/PToolbox.vue
+++ b/src/navigation/toolbox/PToolbox.vue
@@ -298,9 +298,10 @@ export default defineComponent<ToolboxProps>({
             const queryTags = props.queryTags ? props.queryTags.map((queryTag: QueryItem) => {
                 const { key, value } = queryTag;
                 if (!key || !value) return queryTag;
+                const valueSetLabel = state.valueSetMap[key.name]?.label;
                 return {
                     ...queryTag,
-                    value: { ...value, label: (state.valueSetMap[key.name]) ? state.valueSetMap[key.name][value.name]?.label : value.name },
+                    value: { ...value, label: valueSetLabel ?? value.label ?? value.name },
                 };
             }) : [];
             setQueryTags(queryTags);


### PR DESCRIPTION
## To Reviewers
- [x] Skipping reviews is not a problem

## Type of Change
- [x] New feature
- [x] Bug fixes
- [ ] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


## Description
- query search: make only !. != operators available in null case
- toolbox: make use value label when initiating query tags (there was a bug not using value label when value set is empty)

## Things to Talk About
