### PR TITLE
feat(button-modal): add spec of ```position``` for popup

### DIFF
--- a/src/feedbacks/modals/button-modal/PButtonModal.stories.mdx
+++ b/src/feedbacks/modals/button-modal/PButtonModal.stories.mdx
@@ -33,6 +33,7 @@ export const Template = (args, {argTypes} ) => ({
                                 :footer-reset-button-visible="footerResetButtonVisible"
                                 :loading="loading"
                                 :disabled="disabled"
+                                :position="position"
                                 @close="closeModal"
                 >
                     <template #body>

--- a/src/feedbacks/modals/button-modal/PButtonModal.stories.mdx
+++ b/src/feedbacks/modals/button-modal/PButtonModal.stories.mdx
@@ -33,7 +33,7 @@ export const Template = (args, {argTypes} ) => ({
                                 :footer-reset-button-visible="footerResetButtonVisible"
                                 :loading="loading"
                                 :disabled="disabled"
-                                :position="position"
+                                :absolute="absolute"
                                 @close="closeModal"
                 >
                     <template #body>

--- a/src/feedbacks/modals/button-modal/PButtonModal.vue
+++ b/src/feedbacks/modals/button-modal/PButtonModal.vue
@@ -2,8 +2,8 @@
     <section class="p-button-modal">
         <transition v-if="visible" name="modal">
             <div class="modal-mask"
-                 :class="[{'no-backdrop':!backdrop}, {'position': position}]"
-                 :style="position ? [{'top': `${position}rem`}, {'left': `${position}rem`}] : {}"
+                 :class="[{'no-backdrop':!backdrop}, {'absolute': !!absolute}]"
+                 :style="absolute ? [{'top': `${absolute}rem`}, {'left': `${absolute}rem`}] : {}"
             >
                 <div class="modal-wrapper" :class="dialogClassObject"
                      role="dialog"
@@ -119,7 +119,7 @@ export default defineComponent<ButtonModalProps>({
             type: Boolean,
             default: true,
         },
-        position: {
+        absolute: {
             type: Number,
             default: undefined,
         },
@@ -348,7 +348,7 @@ export default defineComponent<ButtonModalProps>({
 
 @screen mobile {
     .modal-mask {
-        &.position {
+        &.absolute {
             left: 0.75rem !important;
         }
     }

--- a/src/feedbacks/modals/button-modal/PButtonModal.vue
+++ b/src/feedbacks/modals/button-modal/PButtonModal.vue
@@ -1,7 +1,10 @@
 <template>
     <section class="p-button-modal">
         <transition v-if="visible" name="modal">
-            <div class="modal-mask" :class="{'no-backdrop':!backdrop}">
+            <div class="modal-mask"
+                 :class="[{'no-backdrop':!backdrop}, {'position': position}]"
+                 :style="position ? [{'top': `${position}rem`}, {'left': `${position}rem`}] : {}"
+            >
                 <div class="modal-wrapper" :class="dialogClassObject"
                      role="dialog"
                      aria-modal="true"
@@ -115,6 +118,10 @@ export default defineComponent<ButtonModalProps>({
         backdrop: {
             type: Boolean,
             default: true,
+        },
+        position: {
+            type: Number,
+            default: undefined,
         },
         themeColor: {
             type: String,
@@ -338,5 +345,13 @@ export default defineComponent<ButtonModalProps>({
 .modal-alert { @mixin modal-color theme('colors.alert'); }
 .modal-gray900 { @mixin modal-color theme('colors.gray.900'); }
 .modal-gray { @mixin modal-color theme('colors.gray.default'); }
+
+@screen mobile {
+    .modal-mask {
+        &.position {
+            left: 0.75rem !important;
+        }
+    }
+}
 
 </style>

--- a/src/feedbacks/modals/button-modal/story-helper.ts
+++ b/src/feedbacks/modals/button-modal/story-helper.ts
@@ -258,6 +258,24 @@ export const getButtonModalArgTypes = (): ArgTypes => ({
             type: 'boolean',
         },
     },
+    position: {
+        name: 'position',
+        type: { name: 'number' },
+        description: 'set position by absolute, with [{top: {position}rem}, {left: {position}rem}]',
+        defaultValue: 0,
+        table: {
+            type: {
+                summary: 'number',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: 0,
+            },
+        },
+        control: {
+            type: 'number',
+        },
+    },
     // model
     'v-model': {
         name: 'v-model',

--- a/src/feedbacks/modals/button-modal/story-helper.ts
+++ b/src/feedbacks/modals/button-modal/story-helper.ts
@@ -258,10 +258,10 @@ export const getButtonModalArgTypes = (): ArgTypes => ({
             type: 'boolean',
         },
     },
-    position: {
-        name: 'position',
+    absolute: {
+        name: 'absolute',
         type: { name: 'number' },
-        description: 'set position by absolute, with [{top: {position}rem}, {left: {position}rem}]',
+        description: 'set position by absolute, with [{top: {absolute}rem}, {left: {absolute}rem}]',
         defaultValue: 0,
         table: {
             type: {

--- a/src/feedbacks/modals/modal.pcss
+++ b/src/feedbacks/modals/modal.pcss
@@ -14,6 +14,15 @@
     &.no-backdrop {
         background-color: transparent;
     }
+    &.position {
+        position: absolute;
+        justify-content: unset;
+        align-items: unset;
+        top: unset;
+        left: unset;
+        width: unset;
+        height: unset;
+    }
 }
 .modal-wrapper {
     overflow: hidden;

--- a/src/feedbacks/modals/modal.pcss
+++ b/src/feedbacks/modals/modal.pcss
@@ -14,7 +14,7 @@
     &.no-backdrop {
         background-color: transparent;
     }
-    &.position {
+    &.absolute {
         position: absolute;
         justify-content: unset;
         align-items: unset;


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [x] Tested with console

### Description

To use button-modal as popup, it is needed `position` attribute
If `position` prop is served, set button-modal `position: absolute; left: {position}rem; right: {position}rem`

![스크린샷 2022-08-04 오후 7 09 18](https://user-images.githubusercontent.com/29014433/182822098-52586097-84d4-4fac-b508-bf8e1bdacfd3.png)

* On mobile, `left` is always 0.75rem when `position` prop is served

### Things to Talk About
