### PR TITLE
feat(popover): add isVisible prop to Popover component

### DIFF
--- a/src/data-display/popover/PPopover.stories.mdx
+++ b/src/data-display/popover/PPopover.stories.mdx
@@ -22,7 +22,7 @@ export const Template = (args, { argTypes }) => ({
             <p-popover :position="_position" :isVisible="_isVisible"
                        :ignore-target-click="ignoreTargetClick" :trigger="trigger">
                 <div v-if="defaultSlot" v-html="defaultSlot" />
-                <p-button v-else style-type="primary" :outline="true" @click="onClick">default</p-button>
+                <p-button v-else style-type="primary" :outline="true" @click="handleClick">default</p-button>
                 <template #content>
                     <div v-if="contentRefSlot" v-html="contentRefSlot" />
                     <div v-else>
@@ -38,28 +38,28 @@ export const Template = (args, { argTypes }) => ({
             _isVisible: props.isVisible,
             defautlContentValue: faker.lorem.sentence(10),
         })
-        const onClick = () => {
+        const handleClick = () => {
             alert('default slot clicked')
         }
         return {
             ...toRefs(state),
-            onClick,
+            handleClick,
         }
     }
 });
 
 
-# PPopover
+# Popover
 <br/>
 <br/>
 
-## Trigger
+## Basic
 
 <br/>
 <br/>
 
 <Canvas>
-    <Story name="Trigger">
+    <Story name="Basic">
         {{
             components: { PPopover, PTextInput, PButton },
             template: `

--- a/src/data-display/popover/story-helper.ts
+++ b/src/data-display/popover/story-helper.ts
@@ -4,6 +4,43 @@ import { POPOVER_PLACEMENT, POPOVER_TRIGGER } from '@/data-display/popover/type'
 
 export const getPopoverArgTypes = () => {
     const argTypes: ArgTypes = {
+        // props
+        isVisible: {
+            name: 'isVisible',
+            type: { name: 'boolean' },
+            description: 'Whether to show popover or not. support two way binding with `sync`.',
+            defaultValue: false,
+            table: {
+                type: {
+                    summary: 'boolean',
+                },
+                category: 'props',
+                defaultValue: {
+                    summary: 'false',
+                },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
+        tag: {
+            name: 'tag',
+            type: { name: 'string' },
+            description: 'root element tag',
+            defaultValue: 'span',
+            table: {
+                type: {
+                    summary: 'string',
+                },
+                category: 'props',
+                defaultValue: {
+                    summary: 'span',
+                },
+            },
+            control: {
+                type: 'text',
+            },
+        },
         position: {
             name: 'position',
             type: { name: 'string' },
@@ -62,6 +99,24 @@ export const getPopoverArgTypes = () => {
                 type: 'boolean',
             },
         },
+        // model
+        'v-model': {
+            name: 'v-model',
+            type: { name: 'boolean', required: false },
+            description: 'Two way binding for `isVisible` props with `update:isVisible` event.',
+            defaultValue: false,
+            table: {
+                type: {
+                    summary: 'boolean',
+                },
+                category: 'model',
+                defaultValue: {
+                    summary: null,
+                },
+            },
+            control: null,
+        },
+        // slots
         defaultSlot: {
             name: 'default',
             description: 'Slot of components to which popover will be applied.',
@@ -93,6 +148,67 @@ export const getPopoverArgTypes = () => {
             },
             control: {
                 type: 'text',
+            },
+        },
+        // events
+        onClick: {
+            name: 'click',
+            description: 'Emitted when the trigger is clicked.',
+            table: {
+                type: {
+                    summary: null,
+                },
+                category: 'events',
+            },
+        },
+        onMouseenter: {
+            name: 'mouseenter',
+            description: 'Emitted when the mouse is entered to the trigger.',
+            table: {
+                type: {
+                    summary: null,
+                },
+                category: 'events',
+            },
+        },
+        onMouseleave: {
+            name: 'mouseleave',
+            description: 'Emitted when the mouse is leaved from the trigger.',
+            table: {
+                type: {
+                    summary: null,
+                },
+                category: 'events',
+            },
+        },
+        onFocus: {
+            name: 'focus',
+            description: 'Emitted when the trigger is focused.',
+            table: {
+                type: {
+                    summary: null,
+                },
+                category: 'events',
+            },
+        },
+        onBlur: {
+            name: 'blur',
+            description: 'Emitted when the trigger is blurred.',
+            table: {
+                type: {
+                    summary: null,
+                },
+                category: 'events',
+            },
+        },
+        'onUpdate:isVisible': {
+            name: 'update:is-visible',
+            description: 'Emitted when the popover visibility is updated. Event parameter - `visible: boolean`',
+            table: {
+                type: {
+                    summary: null,
+                },
+                category: 'events',
             },
         },
     };

--- a/src/data-display/popover/type.ts
+++ b/src/data-display/popover/type.ts
@@ -1,4 +1,4 @@
-export const POPOVER_PLACEMENT = Object.freeze({
+export const POPOVER_PLACEMENT = {
     BOTTOM_START: 'bottom-start',
     BOTTOM_END: 'bottom-end',
     BOTTOM: 'bottom',
@@ -11,14 +11,14 @@ export const POPOVER_PLACEMENT = Object.freeze({
     RIGHT_START: 'right-start',
     RIGHT_END: 'right-end',
     RIGHT: 'right',
-} as const);
+} as const;
 
-export type POPOVER_PLACEMENT = typeof POPOVER_PLACEMENT[keyof typeof POPOVER_PLACEMENT];
+export type PopoverPlacement = typeof POPOVER_PLACEMENT[keyof typeof POPOVER_PLACEMENT];
 
-export const POPOVER_TRIGGER = Object.freeze({
+export const POPOVER_TRIGGER = {
     CLICK: 'click',
     HOVER: 'hover',
     FOCUS: 'focus',
-} as const);
+} as const;
 
-export type POPOVER_TRIGGER = typeof POPOVER_TRIGGER[keyof typeof POPOVER_TRIGGER];
+export type PopoverTrigger = typeof POPOVER_TRIGGER[keyof typeof POPOVER_TRIGGER];


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [x] Tested with console

### Description

- Add `isVisible` prop to Popover component (two-way binding with `update:is-visible` event)
- Remove `scoped` from style of Popover component
- Add event and missing prop to Popover component storybook ArgsTable
- Changed Popover component to use `defineComponent` and other refactorings
- Update images (assets head update)

--- 

- Popover 컴포넌트에 `isVisible` prop 추가 (`update:is-visible` 이벤트로 양방향 바인딩)
- Popover 컴포넌트의 스타일에서 `scoped` 삭제
- Popover 컴포넌트 스토리북 ArgsTable에 이벤트 및 누락된 prop 추가
- Popover 컴포넌트 `defineComponent` 사용하도록 변경 및 기타 리팩토링
- 이미지 업데이트 (에셋 헤드 업데이트)

### Things to Talk About
