### PR TITLE
feat(json-schema-form): add language prop to support i18n

### DIFF
--- a/src/inputs/forms/new-json-schema-form/PJsonSchemaForm.stories.mdx
+++ b/src/inputs/forms/new-json-schema-form/PJsonSchemaForm.stories.mdx
@@ -12,6 +12,7 @@ import {
 import {
     getDefaultFormData, getDefaultSchema
 } from "@/inputs/forms/new-json-schema-form/mock";
+import {supportLanguages} from "@/translations";
 
 
 <Meta title='Inputs/Forms/Json Schema Form' parameters={{
@@ -28,6 +29,7 @@ export const Template = (args, { argTypes }) => ({
         <p-json-schema-form
             :schema="schema"
             :form-data.sync="proxyFormData"
+            :language="language"
         />
     `,
     setup(props) {
@@ -81,6 +83,49 @@ export const Template = (args, { argTypes }) => ({
 
 <br/>
 <br/>
+
+## Language
+
+<Canvas>
+    <Story name="Language" >
+        {{
+            components: { PJsonSchemaForm, PTextEditor, PSelectDropdown },
+            template: `
+<div class="grid grid-cols-12">
+    <p-json-schema-form
+        class="col-span-6"
+        :schema="schema"
+        :form-data="formData"
+        :language="language"
+    />
+    <div class="col-span-6">
+        <p-select-dropdown class="mb-4"
+                           :selected.sync="language" :items="languages" />
+        <p-text-editor :code="JSON.stringify(schema, null, 2)"
+                       mode="readOnly"
+                       folded
+        />
+    </div>
+</div>
+`,
+            setup(props) {
+                const state = reactive({
+                    schema: getDefaultSchema(),
+                    formData: getDefaultFormData(),
+                    language: 'en',
+                    languages: supportLanguages.map(d => ({name: d, label: d}))
+                })
+                return {
+                    ...toRefs(state),
+                }
+            }
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
 
 ## Playground
 

--- a/src/inputs/forms/new-json-schema-form/PJsonSchemaForm.vue
+++ b/src/inputs/forms/new-json-schema-form/PJsonSchemaForm.vue
@@ -36,6 +36,7 @@ import {
     NUMERIC_TYPES,
     refineValueByProperty,
 } from '@/inputs/forms/new-json-schema-form/helper';
+import { useLocalize } from '@/inputs/forms/new-json-schema-form/localize';
 import type {
     InnerJsonSchema,
     JsonSchema,
@@ -44,6 +45,8 @@ import type {
 import { TEXT_INPUT_TYPES } from '@/inputs/forms/new-json-schema-form/type';
 import { useValidation } from '@/inputs/forms/new-json-schema-form/validation';
 import PTextInput from '@/inputs/input/PTextInput.vue';
+import type { SupportLanguage } from '@/translations';
+import { supportLanguages } from '@/translations';
 
 
 export default defineComponent<JsonSchemaFormProps>({
@@ -60,6 +63,13 @@ export default defineComponent<JsonSchemaFormProps>({
         formData: {
             type: Object,
             default: undefined,
+        },
+        language: {
+            type: String as PropType<SupportLanguage>,
+            default: 'en',
+            validator(lang?: SupportLanguage) {
+                return lang === undefined || supportLanguages.includes(lang);
+            },
         },
     },
     setup(props, { emit }) {
@@ -79,11 +89,12 @@ export default defineComponent<JsonSchemaFormProps>({
             contextKey: Math.floor(Math.random() * Date.now()),
         });
 
+        const { localize } = useLocalize(props);
         const {
             invalidMessages, inputOccurred,
             validateFormData, getPropertyInvalidState,
         } = useValidation(props, {
-            formData: computed(() => state.proxyFormData),
+            localize, formData: computed(() => state.proxyFormData),
         });
 
         const getInputTypeBySchemaProperty = (schemaProperty: InnerJsonSchema) => {

--- a/src/inputs/forms/new-json-schema-form/localize.ts
+++ b/src/inputs/forms/new-json-schema-form/localize.ts
@@ -1,0 +1,42 @@
+import { reactive, toRefs, watch } from '@vue/composition-api';
+
+import type { Localize } from 'ajv-i18n/localize/types';
+
+import type { JsonSchemaFormProps } from '@/inputs/forms/new-json-schema-form/type';
+import type { SupportLanguage } from '@/translations';
+
+export const LOCALIZE_LOADERS: Record<SupportLanguage, () => Promise<Localize>> = {
+    en: async () => { const module = await import('ajv-i18n/localize/en'); return module.default; },
+    ko: async () => { const module = await import('ajv-i18n/localize/ko'); return module.default; },
+    jp: async () => { const module = await import('ajv-i18n/localize/ja'); return module.default; },
+};
+
+const localizeMap: Record<SupportLanguage, any|boolean> = {
+    en: undefined,
+    ko: undefined,
+    jp: undefined,
+};
+
+
+export const useLocalize = (props: JsonSchemaFormProps) => {
+    const state = reactive({
+        localize: null as Localize|null,
+    });
+
+    watch(() => props.language, async (language) => {
+        if (!language) {
+            state.localize = null;
+            return;
+        }
+        const localize = localizeMap[language] ?? await LOCALIZE_LOADERS[language]?.();
+        if (!localize) {
+            state.localize = null;
+            return;
+        }
+
+        localizeMap[language] = localize;
+        state.localize = localize;
+    }, { immediate: true });
+
+    return toRefs(state);
+};

--- a/src/inputs/forms/new-json-schema-form/story-helper.ts
+++ b/src/inputs/forms/new-json-schema-form/story-helper.ts
@@ -1,6 +1,7 @@
 import type { ArgTypes } from '@storybook/addons';
 
 import { getDefaultFormData, getDefaultSchema } from '@/inputs/forms/new-json-schema-form/mock';
+import { supportLanguages } from '@/translations';
 
 export const getJsonSchemaFormArgTypes = (): ArgTypes => ({
     schema: {
@@ -37,6 +38,24 @@ export const getJsonSchemaFormArgTypes = (): ArgTypes => ({
         },
         control: {
             type: 'object',
+        },
+    },
+    language: {
+        name: 'language',
+        type: { name: 'string' },
+        defaultValue: supportLanguages[0],
+        table: {
+            type: {
+                summary: 'string',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: supportLanguages[0],
+            },
+        },
+        control: {
+            type: 'select',
+            options: supportLanguages,
         },
     },
     // events

--- a/src/inputs/forms/new-json-schema-form/type.ts
+++ b/src/inputs/forms/new-json-schema-form/type.ts
@@ -1,3 +1,5 @@
+import type { SupportLanguage } from '@/translations';
+
 export const TEXT_INPUT_TYPES = ['string', 'number', 'integer'] as const;
 
 type JsonSchemaType = typeof TEXT_INPUT_TYPES[number]
@@ -24,4 +26,5 @@ export interface InnerJsonSchema extends JsonSchema {
 export interface JsonSchemaFormProps {
     schema?: JsonSchema;
     formData?: object;
+    language?: SupportLanguage;
 }

--- a/src/inputs/forms/new-json-schema-form/validation.ts
+++ b/src/inputs/forms/new-json-schema-form/validation.ts
@@ -5,12 +5,14 @@ import {
 
 import type { ErrorObject, ValidateFunction } from 'ajv';
 import Ajv from 'ajv';
+import type { Localize } from 'ajv-i18n/localize/types';
 import { isEmpty } from 'lodash';
 
 import type { JsonSchemaFormProps, InnerJsonSchema } from '@/inputs/forms/new-json-schema-form/type';
 
-export const useValidation = (props: JsonSchemaFormProps, { formData }: {
+export const useValidation = (props: JsonSchemaFormProps, { formData, localize }: {
     formData: Ref<object>;
+    localize: Ref<Localize|null>;
 }) => {
     const ajv = new Ajv({
         allErrors: true,
@@ -27,6 +29,10 @@ export const useValidation = (props: JsonSchemaFormProps, { formData }: {
             const errorObj = {};
 
             if (state.validatorErrors) {
+                if (localize.value) {
+                    localize.value(state.validatorErrors);
+                }
+
                 state.validatorErrors.forEach((error) => {
                     if (!error.instancePath) {
                         /*


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [x] Tested with console

### Description

By adding the `language` prop, the three languages (en, ko, jp) supported by the design system are reflected in the validation result message.

---

`language` prop을 추가하여 validation 결과 메시지에 디자인 시스템이 지원하는 3개 언어(en, ko, jp)가 반영되도록 적용함


![image](https://user-images.githubusercontent.com/26986739/188047693-8a159ed4-013e-4a7b-94cc-ac46729c515e.png)
![image](https://user-images.githubusercontent.com/26986739/188047727-29c5b67f-6104-4391-a5af-95c5c1d9c22b.png)
![image](https://user-images.githubusercontent.com/26986739/188047756-5e879289-a866-491f-b203-0ba0a779074c.png)


### Things to Talk About
