### PR TITLE
feat(text-input): add show/hide button when type is password

### DIFF
--- a/src/inputs/input/PTextInput.stories.mdx
+++ b/src/inputs/input/PTextInput.stories.mdx
@@ -23,6 +23,8 @@ export const Template = (args, { argTypes }) => ({
                       :disabled="disabled" :block="block"
                       :menu="menu" :use-fixed-menu-style="useFixedMenuStyle"
                       :loading="loading"
+                      :visible-password="visiblePassword"
+                      :type="type"
         >
             <template v-if="rightExtraSlot" #right-extra>
                 <span v-html="rightExtraSlot"></span>
@@ -153,6 +155,27 @@ export const Template = (args, { argTypes }) => ({
             components: { PTextInput },
             template: `
                 <p-text-input v-model="value" type="password" />
+            `,
+            setup() {
+                const state = reactive({
+                    value: 'password'
+                })
+                return {
+                    ...toRefs(state)
+                }
+            }
+        }}
+    </Story>
+</Canvas>
+
+#### Visible Password
+
+<Canvas>
+    <Story name="Visible Password">
+        {{
+            components: { PTextInput },
+            template: `
+                <p-text-input v-model="value" type="password" visible-password />
             `,
             setup() {
                 const state = reactive({

--- a/src/inputs/input/PTextInput.stories.mdx
+++ b/src/inputs/input/PTextInput.stories.mdx
@@ -23,7 +23,7 @@ export const Template = (args, { argTypes }) => ({
                       :disabled="disabled" :block="block"
                       :menu="menu" :use-fixed-menu-style="useFixedMenuStyle"
                       :loading="loading"
-                      :visible-password="visiblePassword"
+                      :password-visibility-mode="passwordVisibilityMode"
                       :type="type"
         >
             <template v-if="rightExtraSlot" #right-extra>
@@ -175,7 +175,7 @@ export const Template = (args, { argTypes }) => ({
         {{
             components: { PTextInput },
             template: `
-                <p-text-input v-model="value" type="password" visible-password />
+                <p-text-input v-model="value" type="password" password-visibility-mode />
             `,
             setup() {
                 const state = reactive({

--- a/src/inputs/input/PTextInput.stories.mdx
+++ b/src/inputs/input/PTextInput.stories.mdx
@@ -23,7 +23,7 @@ export const Template = (args, { argTypes }) => ({
                       :disabled="disabled" :block="block"
                       :menu="menu" :use-fixed-menu-style="useFixedMenuStyle"
                       :loading="loading"
-                      :password-visibility-mode="passwordVisibilityMode"
+                      :visible-input-masking="visibleInputMasking"
                       :type="type"
         >
             <template v-if="rightExtraSlot" #right-extra>
@@ -175,7 +175,7 @@ export const Template = (args, { argTypes }) => ({
         {{
             components: { PTextInput },
             template: `
-                <p-text-input v-model="value" type="password" password-visibility-mode />
+                <p-text-input v-model="value" type="password" visible-input-masking />
             `,
             setup() {
                 const state = reactive({

--- a/src/inputs/input/PTextInput.vue
+++ b/src/inputs/input/PTextInput.vue
@@ -18,7 +18,8 @@
                     {{ tag.label || tag.value }}
                 </p-tag>
                 <slot name="default" v-bind="{ value }">
-                    <input :type="inputType"
+                    <input v-bind="$attrs"
+                           :type="inputType"
                            :value="proxyValue"
                            :disabled="disabled"
                            :placeholder="placeholder"
@@ -28,7 +29,8 @@
                 </slot>
             </div>
             <slot v-else name="default" v-bind="{ value }">
-                <input :type="inputType"
+                <input v-bind="$attrs"
+                       :type="inputType"
                        :value="proxyValue"
                        :disabled="disabled"
                        :placeholder="placeholder"
@@ -41,12 +43,12 @@
                     {{ value }}
                 </slot>
             </span>
-            <p-button v-if="($attrs.type === 'password') && visiblePassword"
+            <p-button v-if="(initialInputType === 'password') && passwordVisibilityMode"
                       size="sm"
                       style-type="transparent"
                       font-weight="normal"
                       :disabled="disabled"
-                      @click="handleTogglePassword"
+                      @click.stop.prevent="handleTogglePassword"
             >
                 {{ isPasswordVisible ? $t('COMPONENT.TEXT_INPUT.HIDE') : $t('COMPONENT.TEXT_INPUT.SHOW') }}
             </p-button>
@@ -88,7 +90,7 @@ import PButton from '@/inputs/buttons/button/PButton.vue';
 import PContextMenu from '@/inputs/context-menu/PContextMenu.vue';
 import type { MenuItem } from '@/inputs/context-menu/type';
 import type { SearchDropdownMenuItem } from '@/inputs/dropdown/search-dropdown/type';
-import type { HTMLInputTypeAttribute, SelectedItem, TextInputHandler } from '@/inputs/input/type';
+import type { SelectedItem, TextInputHandler } from '@/inputs/input/type';
 
 
 interface TextInputProps {
@@ -107,7 +109,7 @@ interface TextInputProps {
     disableHandler: boolean;
     exactMode: boolean;
     useAutoComplete: boolean;
-    visiblePassword: boolean;
+    passwordVisibilityMode: boolean;
 }
 
 export default defineComponent<TextInputProps>({
@@ -190,7 +192,7 @@ export default defineComponent<TextInputProps>({
             type: Boolean,
             default: false,
         },
-        visiblePassword: {
+        passwordVisibilityMode: {
             type: Boolean,
             default: false,
         },
@@ -211,8 +213,9 @@ export default defineComponent<TextInputProps>({
             menuRef: null,
             targetRef: null,
             isFocused: false,
-            inputType: (attrs?.type) ?? 'text' as HTMLInputTypeAttribute,
-            isPasswordVisible: false,
+            initialInputType: attrs.type,
+            inputType: useProxyValue('type', attrs, emit),
+            isPasswordVisible: computed(() => state.inputType !== 'password'),
             proxyValue: useProxyValue('value', props, emit),
             proxySelectedValue: useProxyValue('selected', props, emit),
             deleteTarget: undefined as string | undefined,
@@ -300,8 +303,7 @@ export default defineComponent<TextInputProps>({
         };
 
         const handleTogglePassword = () => {
-            state.isPasswordVisible = !state.isPasswordVisible;
-            state.inputType = state.isPasswordVisible ? 'text' : 'password';
+            state.inputType = state.isPasswordVisible ? 'password' : 'text';
         };
 
         const deleteSelectedTags = () => {

--- a/src/inputs/input/PTextInput.vue
+++ b/src/inputs/input/PTextInput.vue
@@ -43,14 +43,14 @@
                     {{ value }}
                 </slot>
             </span>
-            <p-button v-if="(initialInputType === 'password') && passwordVisibilityMode"
+            <p-button v-if="($attrs.type === 'password') && visibleInputMasking"
                       size="sm"
                       style-type="transparent"
                       font-weight="normal"
                       :disabled="disabled"
                       @click.stop.prevent="handleTogglePassword"
             >
-                {{ isPasswordVisible ? $t('COMPONENT.TEXT_INPUT.HIDE') : $t('COMPONENT.TEXT_INPUT.SHOW') }}
+                {{ !maskingMode ? $t('COMPONENT.TEXT_INPUT.HIDE') : $t('COMPONENT.TEXT_INPUT.SHOW') }}
             </p-button>
             <p-i v-else
                  v-show="(isFocused || isInvalid)"
@@ -109,7 +109,7 @@ interface TextInputProps {
     disableHandler: boolean;
     exactMode: boolean;
     useAutoComplete: boolean;
-    passwordVisibilityMode: boolean;
+    visibleInputMasking: boolean;
 }
 
 export default defineComponent<TextInputProps>({
@@ -192,7 +192,7 @@ export default defineComponent<TextInputProps>({
             type: Boolean,
             default: false,
         },
-        passwordVisibilityMode: {
+        visibleInputMasking: {
             type: Boolean,
             default: false,
         },
@@ -213,9 +213,14 @@ export default defineComponent<TextInputProps>({
             menuRef: null,
             targetRef: null,
             isFocused: false,
-            initialInputType: attrs.type,
-            inputType: useProxyValue('type', attrs, emit),
-            isPasswordVisible: computed(() => state.inputType !== 'password'),
+            maskingMode: true,
+            inputType: computed(() => {
+                if (props.visibleInputMasking) {
+                    if (attrs.type === 'password') return state.maskingMode ? 'password' : 'text';
+                    return attrs.type;
+                }
+                return attrs.type;
+            }),
             proxyValue: useProxyValue('value', props, emit),
             proxySelectedValue: useProxyValue('selected', props, emit),
             deleteTarget: undefined as string | undefined,
@@ -303,7 +308,7 @@ export default defineComponent<TextInputProps>({
         };
 
         const handleTogglePassword = () => {
-            state.inputType = state.isPasswordVisible ? 'password' : 'text';
+            state.maskingMode = !state.maskingMode;
         };
 
         const deleteSelectedTags = () => {
@@ -365,6 +370,9 @@ export default defineComponent<TextInputProps>({
         watch(() => props.menu, (menu) => {
             state.filteredMenu = menu;
             filterMenu(state.proxyValue);
+        });
+        watch(() => props.visibleInputMasking, (visibleInputMasking) => {
+            if (visibleInputMasking) state.maskingMode = true;
         });
 
         const init = () => {

--- a/src/inputs/input/story-helper.ts
+++ b/src/inputs/input/story-helper.ts
@@ -247,8 +247,8 @@ export const getTextInputArgTypes = (): ArgTypes => {
                 type: 'boolean',
             },
         },
-        visiblePassword: {
-            name: 'visiblePassword',
+        passwordVisibilityMode: {
+            name: 'passwordVisibilityMode',
             type: { name: 'boolean' },
             description: 'Use this prop when you want to control show/hide button of password input.',
             defaultValue: false,

--- a/src/inputs/input/story-helper.ts
+++ b/src/inputs/input/story-helper.ts
@@ -247,6 +247,24 @@ export const getTextInputArgTypes = (): ArgTypes => {
                 type: 'boolean',
             },
         },
+        visiblePassword: {
+            name: 'visiblePassword',
+            type: { name: 'boolean' },
+            description: 'Use this prop when you want to control show/hide button of password input.',
+            defaultValue: false,
+            table: {
+                type: {
+                    summary: 'boolean',
+                },
+                category: 'props',
+                defaultValue: {
+                    summary: 'false',
+                },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
         // attrs
         inputAttrs: {
             name: 'all input attributes',
@@ -262,6 +280,23 @@ export const getTextInputArgTypes = (): ArgTypes => {
                 category: 'attrs',
             },
             control: null,
+        },
+        type: {
+            name: 'type',
+            description: 'type of input tag (e.g. text, password, date ...)',
+            defaultValue: 'text',
+            table: {
+                type: {
+                    summary: null,
+                },
+                defaultValue: {
+                    summary: 'text',
+                },
+                category: 'attrs',
+            },
+            control: {
+                type: 'text',
+            },
         },
         // model
         'v-model': {

--- a/src/inputs/input/story-helper.ts
+++ b/src/inputs/input/story-helper.ts
@@ -247,8 +247,8 @@ export const getTextInputArgTypes = (): ArgTypes => {
                 type: 'boolean',
             },
         },
-        passwordVisibilityMode: {
-            name: 'passwordVisibilityMode',
+        visibleInputMasking: {
+            name: 'visibleInputMasking',
             type: { name: 'boolean' },
             description: 'Use this prop when you want to control show/hide button of password input.',
             defaultValue: false,

--- a/src/inputs/input/type.ts
+++ b/src/inputs/input/type.ts
@@ -12,3 +12,7 @@ export interface SelectedItem {
 export interface TextInputHandler {
     (val: string, searchableItems: MenuItem[]): Promise<{results: MenuItem[]}>|{results: MenuItem[]}
 }
+
+// eslint-disable-next-line max-len
+type HTMLInputTypeAttribute = null | 'button' | 'checkbox' | 'color' | 'date' | 'datetime-local' | 'email' | 'file' | 'hidden' | 'image' | 'month' | 'number' | 'password' | 'radio' | 'range' | 'reset' | 'search' | 'submit' | 'tel' | 'text' | 'time' | 'url' | 'week';
+export type { HTMLInputTypeAttribute };

--- a/src/inputs/input/type.ts
+++ b/src/inputs/input/type.ts
@@ -12,7 +12,3 @@ export interface SelectedItem {
 export interface TextInputHandler {
     (val: string, searchableItems: MenuItem[]): Promise<{results: MenuItem[]}>|{results: MenuItem[]}
 }
-
-// eslint-disable-next-line max-len
-type HTMLInputTypeAttribute = null | 'button' | 'checkbox' | 'color' | 'date' | 'datetime-local' | 'email' | 'file' | 'hidden' | 'image' | 'month' | 'number' | 'password' | 'radio' | 'range' | 'reset' | 'search' | 'submit' | 'tel' | 'text' | 'time' | 'url' | 'week';
-export type { HTMLInputTypeAttribute };


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [x] Tested with console

### Description

https://user-images.githubusercontent.com/50662170/188075152-5f2f60b6-8e03-4d60-bbb0-12f9dc3e6f76.mov

- add show/hide button when type is password
- Add function to enable operation of input type in playground
---
- type이 password인 경우 show/hide 버튼 추가
- playground에서 attrs의 type도 세팅가능하도록 기능 추가
### Things to Talk About
